### PR TITLE
feat(apply): support Homebrew 6.0 tap trust and ask prompt

### DIFF
--- a/crates/keron-apply/src/elevated/mod.rs
+++ b/crates/keron-apply/src/elevated/mod.rs
@@ -71,6 +71,7 @@ pub fn run_elevated(plan: &Plan) -> Result<ExecuteSummary> {
         added: summary.add,
         changed: summary.change,
         ran: summary.run,
+        warnings: Vec::new(),
     })
 }
 

--- a/crates/keron-apply/src/execute.rs
+++ b/crates/keron-apply/src/execute.rs
@@ -34,11 +34,38 @@ use crate::plan::{
 };
 use crate::platform::{OsFamily, detect_os_family};
 
-#[derive(Debug, Clone, Copy, Default)]
+/// A non-fatal issue encountered while applying a plan. Collected and
+/// surfaced to the user rather than aborting the run, because none of
+/// them block the outcome the user asked for — only degrade some
+/// secondary behaviour. Kept as a typed enum (not a free-form string)
+/// so callers can pattern-match and tests can assert on the variant.
+#[derive(Debug, Clone)]
+pub enum Warning {
+    /// A managed tap was registered (`brew tap` succeeded) but
+    /// `brew trust` failed. Brew 6.0 fully-qualified installs
+    /// auto-trust per-item, so dependent installs still succeed; only
+    /// `brew doctor` and bare-name installs from the tap are degraded.
+    TapUntrusted { user_tap: String, error: String },
+}
+
+impl std::fmt::Display for Warning {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::TapUntrusted { user_tap, error } => write!(
+                f,
+                "tap `{user_tap}` registered but not trusted; brew 6.0 may warn or \
+                 refuse bare-name installs from it: {error}",
+            ),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default)]
 pub struct ExecuteSummary {
     pub added: usize,
     pub changed: usize,
     pub ran: usize,
+    pub warnings: Vec<Warning>,
 }
 
 pub fn execute(plan: &Plan) -> Result<ExecuteSummary> {
@@ -147,7 +174,12 @@ fn annotate_phase_failure(
 }
 
 fn apply_change(change: &ResourceChange, summary: &mut ExecuteSummary, os: OsFamily) -> Result<()> {
-    apply_change_one_in_with_os(change, ApplyContext::Unprivileged, os)?;
+    apply_change_one_in_with_os(
+        change,
+        ApplyContext::Unprivileged,
+        os,
+        &mut summary.warnings,
+    )?;
     match change.action {
         Action::Create => summary.added += 1,
         Action::Update => summary.changed += 1,
@@ -446,14 +478,19 @@ pub enum ApplyContext {
 pub fn apply_change_one_in(change: &ResourceChange, ctx: ApplyContext) -> Result<()> {
     // Single-change entry: snapshot OS on the caller's thread and pass
     // it down. Same rationale as `execute` — keeps the package
-    // validation path off the `OsOverride` thread-local.
-    apply_change_one_in_with_os(change, ctx, detect_os_family())
+    // validation path off the `OsOverride` thread-local. Warnings are
+    // dropped here: this entry serves the elevated child (which reports
+    // outcomes via its own channel) and single-change tests, and no
+    // warning-producing resource (Tap) is ever elevated.
+    let mut warnings = Vec::new();
+    apply_change_one_in_with_os(change, ctx, detect_os_family(), &mut warnings)
 }
 
 fn apply_change_one_in_with_os(
     change: &ResourceChange,
     ctx: ApplyContext,
     os: OsFamily,
+    warnings: &mut Vec<Warning>,
 ) -> Result<()> {
     match change.action {
         Action::NoOp => Ok(()),
@@ -462,7 +499,8 @@ fn apply_change_one_in_with_os(
                 .after
                 .as_ref()
                 .with_context(|| format!("create `{}` has no desired state", change.address))?;
-            apply_create(state, ctx, os).with_context(|| format!("creating `{}`", change.address))
+            apply_create(state, ctx, os, warnings)
+                .with_context(|| format!("creating `{}`", change.address))
         }
         Action::Update => {
             let before = change
@@ -477,7 +515,7 @@ fn apply_change_one_in_with_os(
             // safe-write walk as Create (anchored to an `O_NOFOLLOW`
             // parent fd), and every update replaces atomically via a
             // temp-then-rename so the target is never left missing.
-            apply_update(before, after, ctx)
+            apply_update(before, after, ctx, warnings)
                 .with_context(|| format!("updating `{}`", change.address))
         }
         Action::Run => {
@@ -490,7 +528,12 @@ fn apply_change_one_in_with_os(
     }
 }
 
-fn apply_create(state: &ResourceState, ctx: ApplyContext, os: OsFamily) -> Result<()> {
+fn apply_create(
+    state: &ResourceState,
+    ctx: ApplyContext,
+    os: OsFamily,
+    warnings: &mut Vec<Warning>,
+) -> Result<()> {
     match state {
         ResourceState::Symlink { from, to } => create_symlink(from, to, ctx),
         ResourceState::Template {
@@ -508,7 +551,7 @@ fn apply_create(state: &ResourceState, ctx: ApplyContext, os: OsFamily) -> Resul
             // no duplicated spawn code.
             packages::install_many(*manager, &[name.as_str()], os)
         }
-        ResourceState::Tap(spec) => packages::tap(spec, Action::Create),
+        ResourceState::Tap(spec) => packages::tap(spec, Action::Create, warnings),
         ResourceState::SshKey {
             private_path,
             public_path,
@@ -534,7 +577,12 @@ fn apply_run(state: &ResourceState) -> Result<()> {
     run_shell(*kind, name, cwd, script)
 }
 
-fn apply_update(before: &ResourceState, after: &ResourceState, ctx: ApplyContext) -> Result<()> {
+fn apply_update(
+    before: &ResourceState,
+    after: &ResourceState,
+    ctx: ApplyContext,
+    warnings: &mut Vec<Warning>,
+) -> Result<()> {
     match (before, after) {
         (
             ResourceState::Symlink {
@@ -591,7 +639,7 @@ fn apply_update(before: &ResourceState, after: &ResourceState, ctx: ApplyContext
         // `--custom-remote` so brew rewrites the local git remote in
         // place. No untap+retap (which would force a re-clone).
         (ResourceState::Tap(_), ResourceState::Tap(after_spec)) => {
-            packages::tap(after_spec, Action::Update)
+            packages::tap(after_spec, Action::Update, warnings)
         }
         _ => bail!(unsupported_kind(after)),
     }

--- a/crates/keron-apply/src/execute_tests.rs
+++ b/crates/keron-apply/src/execute_tests.rs
@@ -296,7 +296,7 @@ fn update_symlink_bails_when_live_state_changed_since_plan() {
         from: link.clone(),
         to: new_target,
     };
-    let err = apply_update(&before, &after, ApplyContext::Unprivileged)
+    let err = apply_update(&before, &after, ApplyContext::Unprivileged, &mut Vec::new())
         .expect_err("changed live state must bail");
     assert!(
         format!("{err:#}").contains("changed since the plan"),
@@ -740,6 +740,7 @@ fn bump_summary_create_increments_added_by_count() {
         added: 2,
         changed: 0,
         ran: 0,
+        warnings: Vec::new(),
     };
     bump_summary(&mut s, Action::Create, 3);
     assert_eq!(s.added, 5, "Create must add count to existing total");
@@ -757,6 +758,7 @@ fn bump_summary_update_increments_changed_by_count() {
         added: 0,
         changed: 4,
         ran: 0,
+        warnings: Vec::new(),
     };
     bump_summary(&mut s, Action::Update, 2);
     assert_eq!(s.added, 0);
@@ -781,7 +783,7 @@ fn apply_update_package_bails_with_planner_bug_diagnostic() {
         name: "ripgrep".into(),
         tap: None,
     };
-    let err = apply_update(&before, &after, ApplyContext::Unprivileged)
+    let err = apply_update(&before, &after, ApplyContext::Unprivileged, &mut Vec::new())
         .expect_err("Package Update must bail");
     let msg = format!("{err:#}");
     assert!(
@@ -824,7 +826,7 @@ fn apply_update_tap_invokes_brew_tap_with_custom_remote() {
         user_tap: "icepuma/keron".into(),
         url: Some("https://github.com/icepuma/keron".into()),
     });
-    let result = apply_update(&before, &after, ApplyContext::Unprivileged);
+    let result = apply_update(&before, &after, ApplyContext::Unprivileged, &mut Vec::new());
     #[allow(unsafe_code)]
     unsafe {
         std::env::remove_var("KERON_TEST_PACKAGE_BIN_BREW");

--- a/crates/keron-apply/src/lib.rs
+++ b/crates/keron-apply/src/lib.rs
@@ -287,7 +287,14 @@ where
     }
 
     let (unprivileged, elevated_plan) = plan.partition_by_elevation();
-    let unpriv_summary = execute::execute(&unprivileged).map_err(RunError::Apply)?;
+    let mut unpriv_summary = execute::execute(&unprivileged).map_err(RunError::Apply)?;
+
+    // Warnings collected during the unprivileged apply (e.g. a managed
+    // tap that registered but couldn't be trusted). The elevated child
+    // never produces these — no warning-yielding resource is elevated —
+    // so the unprivileged summary is the sole source. Spill them after
+    // the status line so the user still sees "Apply complete!" first.
+    let mut warnings = std::mem::take(&mut unpriv_summary.warnings);
 
     if elevated_plan.changes.is_empty() {
         writeln!(
@@ -311,6 +318,7 @@ where
         .map_err(RunError::Io)?;
         let elevated_summary =
             elevated::run_elevated(&elevated_plan).map_err(RunError::Elevation)?;
+        warnings.extend(elevated_summary.warnings);
         writeln!(
             stdout,
             "Apply complete! Resources: {} added, {} changed, {} ran.",
@@ -320,7 +328,17 @@ where
         )
         .map_err(RunError::Io)?;
     }
+    spill_warnings(stdout, &warnings).map_err(RunError::Io)?;
     Ok(Outcome::Applied)
+}
+
+/// Render collected apply warnings to the user, one indented line each.
+/// Empty input writes nothing so a clean run stays quiet.
+fn spill_warnings<W: Write>(stdout: &mut W, warnings: &[execute::Warning]) -> io::Result<()> {
+    for warning in warnings {
+        writeln!(stdout, "warning: {warning}")?;
+    }
+    Ok(())
 }
 
 fn render_precheck<W: Write>(stdout: &mut W, precheck: &plan::Precheck) -> io::Result<()> {

--- a/crates/keron-apply/src/packages/brew.rs
+++ b/crates/keron-apply/src/packages/brew.rs
@@ -1,10 +1,11 @@
 //! Homebrew integration.
 //!
-//! State is observed through three read-only probes:
+//! State is observed through read-only probes:
 //!   - `brew list --formula -1` — installed formulae (bare names)
 //!   - `brew list --cask -1` — installed casks (bare names)
 //!   - `brew tap` — installed taps (`user/repo` per line)
-//!   - `brew tap-info --json USER/REPO` — one tap's remote URL
+//!   - `brew tap-info --json=v1 USER/REPO` — one tap's remote URL and
+//!     trust flag (the `trusted` field is new in brew 6.0)
 //!
 //! All probes run with `HOMEBREW_NO_AUTO_UPDATE=1` so a sleepy local
 //! brew doesn't auto-update mid-classify, polluting stderr and racing
@@ -19,8 +20,15 @@
 //! probe and no `brew upgrade` path. Upgrading installed packages is
 //! the user's job via the underlying manager.
 //!
-//! Mutating commands (`tap`, `install`) inherit stdio so the user
-//! sees real progress bars and download status.
+//! Brew 6.0 introduced tap trust: non-official taps must be explicitly
+//! trusted before their formulae/casks load. Since keron owns a tap's
+//! lifecycle (it taps before it installs), it also trusts every tap it
+//! manages via `brew trust --tap` (see [`do_trust`]).
+//!
+//! Mutating commands (`tap`, `trust`, `install`) inherit stdio so the
+//! user sees real progress bars and download status. Installs are
+//! additionally launched with `HOMEBREW_NO_ASK=1` by the package
+//! executor to skip brew 6.0's new interactive install prompt.
 
 use std::collections::HashSet;
 use std::process::{Command, Stdio};
@@ -33,6 +41,26 @@ use serde::Deserialize;
 /// probe runs on a stale machine — fine interactively, ugly inside
 /// `keron apply`.
 const NO_AUTO_UPDATE: (&str, &str) = ("HOMEBREW_NO_AUTO_UPDATE", "1");
+
+/// Skip brew 6.0's new install confirmation prompt (`-y, --no-ask` is
+/// enabled by default when this is set, per `man brew`). Inert for
+/// read-only commands, load-bearing for installs run with captured or
+/// inherited stdio.
+const NO_ASK: (&str, &str) = ("HOMEBREW_NO_ASK", "1");
+
+/// Apply the brew subprocess environment uniformly to every `brew`
+/// invocation keron makes — probes, taps, trusts and installs. Without
+/// `HOMEBREW_NO_AUTO_UPDATE` a `brew tap`/`brew trust` can kick off an
+/// implicit `brew update`, racing the concurrent install phase for
+/// brew's global lock and producing flaky "Another active Homebrew
+/// process is already in progress" failures; `do_tap` previously forgot
+/// it entirely. The vars are inert for commands that don't trigger the
+/// behaviour, so applying them everywhere is strictly safer than
+/// per-call opt-in.
+pub fn apply_brew_env(cmd: &mut Command) {
+    cmd.env(NO_AUTO_UPDATE.0, NO_AUTO_UPDATE.1);
+    cmd.env(NO_ASK.0, NO_ASK.1);
+}
 
 pub fn fetch_formulae() -> Result<HashSet<String>> {
     let out = brew_probe(&["list", "--formula", "-1"])?;
@@ -49,22 +77,48 @@ pub fn fetch_taps() -> Result<HashSet<String>> {
     Ok(parse_lines(&out))
 }
 
-/// Returns the remote URL of `user_tap` per `brew tap-info --json`.
-/// `Ok(None)` when the tap isn't installed (callers only invoke this
-/// when they believe it is, so a `None` here is mildly surprising but
-/// not an error).
-pub fn fetch_tap_remote(user_tap: &str) -> Result<Option<String>> {
-    let out = brew_probe(&["tap-info", "--json", user_tap])?;
-    let parsed: Vec<TapInfo> = serde_json::from_str(&out)
-        .with_context(|| format!("parsing `brew tap-info --json {user_tap}` output"))?;
-    Ok(parsed.into_iter().next().map(|i| i.remote))
+/// Remote URL and trust state for one tap, from `brew tap-info --json=v1`.
+/// `trusted` is `None` when the field is absent (pre-6.0 brew); callers
+/// treat `None` as "trust not enforced" so older brew never emits a
+/// spurious drift action.
+#[derive(Debug, Clone)]
+pub struct TapInfo {
+    pub remote: Option<String>,
+    pub trusted: Option<bool>,
 }
 
-/// One element of the `brew tap-info --json` array. Only fields we
-/// actually read are deserialized.
+/// Fetch one tap's remote URL and trust flag. `Ok(None)` when the tap
+/// isn't installed (`brew tap-info` returns an empty array). Callers
+/// only invoke this when they believe the tap is installed, so a `None`
+/// is mildly surprising but not an error.
+pub fn fetch_tap_info(user_tap: &str) -> Result<Option<TapInfo>> {
+    let out = brew_probe(&["tap-info", "--json=v1", user_tap])?;
+    let parsed: Vec<TapInfoJson> = serde_json::from_str(&out)
+        .with_context(|| format!("parsing `brew tap-info --json=v1 {user_tap}` output"))?;
+    Ok(parsed.into_iter().next().map(|i| TapInfo {
+        remote: i.remote,
+        trusted: i.trusted,
+    }))
+}
+
+/// One element of the `brew tap-info --json=v1` array. Only fields we
+/// actually read are deserialized; both default so older brew output
+/// (which omits `trusted`) still parses.
 #[derive(Debug, Deserialize)]
-struct TapInfo {
-    remote: String,
+struct TapInfoJson {
+    #[serde(default)]
+    remote: Option<String>,
+    #[serde(default)]
+    trusted: Option<bool>,
+}
+
+/// Canonicalise a tap remote URL for equality comparison. Brew 6.0
+/// ignores a trailing `.git` (and trailing slash) when matching GitHub
+/// remotes, so two forms differing only by those must classify as the
+/// same tap rather than a URL drift that re-taps on every apply.
+pub fn normalize_remote(url: &str) -> &str {
+    let url = url.trim_end_matches('/');
+    url.strip_suffix(".git").unwrap_or(url)
 }
 
 /// Run `brew tap user_tap [URL]`. With `custom_remote=true`, passes
@@ -81,6 +135,7 @@ pub fn do_tap(user_tap: &str, url: Option<&str>, custom_remote: bool) -> Result<
     if let Some(u) = url {
         cmd.arg(u);
     }
+    apply_brew_env(&mut cmd);
     let status = cmd
         .stdin(Stdio::inherit())
         .stdout(Stdio::inherit())
@@ -91,6 +146,43 @@ pub fn do_tap(user_tap: &str, url: Option<&str>, custom_remote: bool) -> Result<
         bail!("`{binary} tap {user_tap}` exited with status {status}");
     }
     Ok(())
+}
+
+/// Run `brew trust --tap user_tap`. Idempotent on brew's side. Brew 6.0
+/// requires non-official taps to be explicitly trusted before their
+/// formulae/casks load; since keron manages a tap's full lifecycle, it
+/// trusts every tap it taps.
+///
+/// `brew trust` shipped in 5.1.15; older brew exits non-zero with an
+/// "unknown command"-style diagnostic. We tolerate that single case so
+/// keron keeps working on pre-6.0 installs, but propagate every other
+/// failure (network, permissions, …). Fully-qualified installs already
+/// auto-trust per-item on 6.0, so a failed `do_trust` only degrades the
+/// `brew doctor` / bare-name experience rather than blocking installs.
+pub fn do_trust(user_tap: &str) -> Result<()> {
+    let binary = test_binary_override().unwrap_or_else(|| "brew".to_string());
+    let mut cmd = Command::new(&binary);
+    cmd.args(["trust", "--tap", user_tap]);
+    apply_brew_env(&mut cmd);
+    let out = cmd
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .with_context(|| format!("spawning `{binary} trust --tap {user_tap}`"))?;
+    if out.status.success() {
+        return Ok(());
+    }
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    let lower = stderr.to_lowercase();
+    if lower.contains("unknown command") || lower.contains("unknown subcommand") {
+        return Ok(());
+    }
+    bail!(
+        "`{binary} trust --tap {user_tap}` exited with status {}; stderr: {}",
+        out.status,
+        stderr.trim(),
+    );
 }
 
 /// Reject tap URLs that would smuggle behavior past `brew tap` — same
@@ -131,14 +223,15 @@ pub fn parse_lines(text: &str) -> HashSet<String> {
         .collect()
 }
 
-/// Shell out to `brew` with `HOMEBREW_NO_AUTO_UPDATE=1` and return
-/// stdout. Routes through the test binary override so unit tests can
-/// pin behavior without a real brew.
+/// Shell out to `brew` with the standard brew env (see
+/// [`apply_brew_env`]) and return stdout. Routes through the test
+/// binary override so unit tests can pin behavior without a real brew.
 fn brew_probe(args: &[&str]) -> Result<String> {
     let binary = test_binary_override().unwrap_or_else(|| "brew".to_string());
-    let out = Command::new(&binary)
-        .args(args)
-        .env(NO_AUTO_UPDATE.0, NO_AUTO_UPDATE.1)
+    let mut cmd = Command::new(&binary);
+    cmd.args(args);
+    apply_brew_env(&mut cmd);
+    let out = cmd
         .stdin(Stdio::null())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
@@ -201,17 +294,62 @@ mod tests {
     }
 
     #[test]
-    fn tap_info_json_extracts_remote() {
-        let json = r#"[{"name":"icepuma/keron","remote":"https://github.com/icepuma/keron","custom_remote":true}]"#;
-        let parsed: Vec<TapInfo> = serde_json::from_str(json).unwrap();
+    fn tap_info_json_extracts_remote_and_trusted() {
+        let json = r#"[{"name":"icepuma/keron","remote":"https://github.com/icepuma/keron","trusted":true,"custom_remote":true}]"#;
+        let parsed: Vec<TapInfoJson> = serde_json::from_str(json).unwrap();
         assert_eq!(parsed.len(), 1);
-        assert_eq!(parsed[0].remote, "https://github.com/icepuma/keron");
+        assert_eq!(
+            parsed[0].remote.as_deref(),
+            Some("https://github.com/icepuma/keron"),
+        );
+        assert_eq!(parsed[0].trusted, Some(true));
+    }
+
+    #[test]
+    fn tap_info_json_defaults_trusted_to_none_when_absent() {
+        // Pre-6.0 brew output omits `trusted`; the field must deserialize
+        // to None rather than erroring so older brew stays supported.
+        let json = r#"[{"name":"icepuma/keron","remote":"https://github.com/icepuma/keron"}]"#;
+        let parsed: Vec<TapInfoJson> = serde_json::from_str(json).unwrap();
+        assert_eq!(parsed[0].trusted, None);
     }
 
     #[test]
     fn tap_info_json_handles_empty_array() {
-        let parsed: Vec<TapInfo> = serde_json::from_str("[]").unwrap();
+        let parsed: Vec<TapInfoJson> = serde_json::from_str("[]").unwrap();
         assert!(parsed.is_empty());
+    }
+
+    #[test]
+    fn normalize_remote_strips_git_suffix() {
+        assert_eq!(
+            normalize_remote("https://github.com/icepuma/keron.git"),
+            "https://github.com/icepuma/keron",
+        );
+    }
+
+    #[test]
+    fn normalize_remote_strips_trailing_slash() {
+        assert_eq!(
+            normalize_remote("https://github.com/icepuma/keron/"),
+            "https://github.com/icepuma/keron",
+        );
+    }
+
+    #[test]
+    fn normalize_remote_strips_git_and_slash() {
+        assert_eq!(
+            normalize_remote("https://github.com/icepuma/keron.git/"),
+            "https://github.com/icepuma/keron",
+        );
+    }
+
+    #[test]
+    fn normalize_remote_passes_through_plain_url() {
+        assert_eq!(
+            normalize_remote("https://github.com/icepuma/keron"),
+            "https://github.com/icepuma/keron",
+        );
     }
 
     #[test]
@@ -264,6 +402,24 @@ mod tests {
             let escaped = line.replace('\\', "\\\\").replace('\'', "'\\''");
             let _ = writeln!(body, "printf '%s\\n' '{escaped}'");
         }
+        let _ = writeln!(body, "exit {exit_code}");
+        std::fs::write(&spy, body).unwrap();
+        std::fs::set_permissions(&spy, std::fs::Permissions::from_mode(0o755)).unwrap();
+        spy
+    }
+
+    #[cfg(unix)]
+    fn write_brew_spy_stderr(
+        dir: &std::path::Path,
+        stderr: &str,
+        exit_code: i32,
+    ) -> std::path::PathBuf {
+        use std::fmt::Write as _;
+        use std::os::unix::fs::PermissionsExt;
+        let spy = dir.join("brew-spy-stderr.sh");
+        let mut body = String::from("#!/bin/sh\n");
+        let escaped = stderr.replace('\\', "\\\\").replace('\'', "'\\''");
+        let _ = writeln!(body, "printf '%s\\n' '{escaped}' >&2");
         let _ = writeln!(body, "exit {exit_code}");
         std::fs::write(&spy, body).unwrap();
         std::fs::set_permissions(&spy, std::fs::Permissions::from_mode(0o755)).unwrap();
@@ -390,6 +546,56 @@ mod tests {
         clear_brew_override();
         let _ = std::fs::remove_dir_all(&dir);
         let err = result.expect_err("nonzero exit must bail");
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("exited with status"),
+            "expected status diagnostic, got: {msg}",
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn do_trust_ok_on_success() {
+        let _g = super::super::lock_env();
+        let dir = spy_dir("do-trust-ok");
+        let spy = write_brew_spy_stderr(&dir, "", 0);
+        set_brew_override(&spy);
+        let result = do_trust("icepuma/keron");
+        clear_brew_override();
+        let _ = std::fs::remove_dir_all(&dir);
+        result.expect("success exit must return Ok");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn do_trust_tolerates_unknown_command_on_older_brew() {
+        // `brew trust` shipped in 5.1.15; older brew rejects it as an
+        // unknown command. do_trust must swallow that single case so
+        // keron keeps working on pre-6.0 installs.
+        let _g = super::super::lock_env();
+        let dir = spy_dir("do-trust-unknown");
+        let spy = write_brew_spy_stderr(&dir, "Error: Unknown command: trust", 1);
+        set_brew_override(&spy);
+        let result = do_trust("icepuma/keron");
+        clear_brew_override();
+        let _ = std::fs::remove_dir_all(&dir);
+        result.expect("unknown-command on older brew must be tolerated");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn do_trust_bails_on_real_error() {
+        // Any non-success exit that isn't the tolerated unknown-command
+        // diagnostic must surface as an error — swallowing it would let
+        // the planner believe a tap is trusted when it isn't.
+        let _g = super::super::lock_env();
+        let dir = spy_dir("do-trust-fail");
+        let spy = write_brew_spy_stderr(&dir, "Error: network down", 1);
+        set_brew_override(&spy);
+        let result = do_trust("icepuma/keron");
+        clear_brew_override();
+        let _ = std::fs::remove_dir_all(&dir);
+        let err = result.expect_err("real error must bail");
         let msg = format!("{err:#}");
         assert!(
             msg.contains("exited with status"),

--- a/crates/keron-apply/src/packages/mod.rs
+++ b/crates/keron-apply/src/packages/mod.rs
@@ -32,12 +32,13 @@
 //! drive any cache state without a real `brew` / `cargo` / `winget`
 //! on the host. Brew has additional seams for casks
 //! (`KERON_TEST_BREW_CASK_PACKAGES`), installed taps
-//! (`KERON_TEST_BREW_TAPS`), and per-tap remote URLs
-//! (`KERON_TEST_BREW_TAP_REMOTES=user/repo=URL;user2/repo2=URL2`).
-//! The install side reads `KERON_TEST_PACKAGE_BIN_<MGR>` to swap the
-//! binary path for a spy script. All seams require
-//! `KERON_ALLOW_TEST_OVERRIDES=1` so stray environment variables
-//! cannot falsify a real run.
+//! (`KERON_TEST_BREW_TAPS`), per-tap remote URLs
+//! (`KERON_TEST_BREW_TAP_REMOTES=user/repo=URL;user2/repo2=URL2`),
+//! and per-tap trust flags (`KERON_TEST_BREW_TAP_TRUSTED=user/repo=true;...`,
+//! defaulting to trusted when unset). The install side reads
+//! `KERON_TEST_PACKAGE_BIN_<MGR>` to swap the binary path for a spy
+//! script. All seams require `KERON_ALLOW_TEST_OVERRIDES=1` so stray
+//! environment variables cannot falsify a real run.
 
 pub mod brew;
 pub mod cargo;
@@ -68,10 +69,10 @@ pub struct PackageCache {
     /// `user/repo` strings from `brew tap`. Loaded lazily on first
     /// `classify_tap` call.
     installed_taps: Option<HashSet<String>>,
-    /// Per-tap remote URL memo, populated on demand via
-    /// `brew tap-info --json`. Only consulted when a tap is already
-    /// installed AND the manifest declared a custom URL.
-    tap_remotes: HashMap<String, Option<String>>,
+    /// Per-tap info (remote URL + trust flag) memo, populated on demand
+    /// via `brew tap-info --json=v1`. The remote is consulted for URL
+    /// drift; the trust flag drives the brew 6.0 tap-trust action.
+    tap_info: HashMap<String, Option<brew::TapInfo>>,
     /// Names already classified as Create in this run — second
     /// occurrence collapses to `NoOp`.
     scheduled: HashMap<PackageManager, HashSet<String>>,
@@ -85,7 +86,7 @@ impl PackageCache {
             os,
             installed: HashMap::new(),
             installed_taps: None,
-            tap_remotes: HashMap::new(),
+            tap_info: HashMap::new(),
             scheduled: HashMap::new(),
             scheduled_taps: HashSet::new(),
         }
@@ -104,7 +105,7 @@ impl PackageCache {
     /// running them concurrently. Walks `resources` to determine which
     /// `(manager, query)` shell-outs would otherwise be incurred
     /// lazily by [`Self::ensure_installed_loaded`] /
-    /// [`Self::ensure_taps_loaded`] / [`Self::tap_remote`], then fans
+    /// [`Self::ensure_taps_loaded`] / [`Self::tap_info`], then fans
     /// them out across `std::thread::scope` worker threads. Each
     /// worker is I/O-bound (waiting on a subprocess), so the wall
     /// time collapses to roughly the slowest probe rather than the
@@ -126,7 +127,7 @@ impl PackageCache {
     pub fn prewarm(&mut self, resources: &[ResourceState]) -> Result<()> {
         let mut needed_installed: HashSet<PackageManager> = HashSet::new();
         let mut need_taps = false;
-        let mut needed_tap_remotes: Vec<String> = Vec::new();
+        let mut needed_tap_infos: Vec<String> = Vec::new();
 
         for state in resources {
             match state {
@@ -139,8 +140,12 @@ impl PackageCache {
                     if self.installed_taps.is_none() {
                         need_taps = true;
                     }
-                    if spec.url.is_some() && !self.tap_remotes.contains_key(&spec.user_tap) {
-                        needed_tap_remotes.push(spec.user_tap.clone());
+                    // Probe every referenced tap (not just URL-qualified
+                    // ones): brew 6.0 trust state is needed to decide
+                    // whether an installed-but-untrusted tap classifies
+                    // as an Update.
+                    if !self.tap_info.contains_key(&spec.user_tap) {
+                        needed_tap_infos.push(spec.user_tap.clone());
                     }
                 }
                 ResourceState::Symlink { .. }
@@ -151,10 +156,10 @@ impl PackageCache {
             }
         }
 
-        needed_tap_remotes.sort();
-        needed_tap_remotes.dedup();
+        needed_tap_infos.sort();
+        needed_tap_infos.dedup();
 
-        if needed_installed.is_empty() && !need_taps && needed_tap_remotes.is_empty() {
+        if needed_installed.is_empty() && !need_taps && needed_tap_infos.is_empty() {
             return Ok(());
         }
 
@@ -169,7 +174,7 @@ impl PackageCache {
         let ProbeResults {
             installed_results,
             taps_result,
-            tap_remote_results,
+            tap_info_results,
         } = std::thread::scope(|s| {
             #[allow(clippy::needless_collect)]
             let installed_handles: Vec<(PackageManager, _)> = installed_managers
@@ -183,12 +188,12 @@ impl PackageCache {
                 None
             };
             #[allow(clippy::needless_collect)]
-            let tap_remote_handles: Vec<(String, _)> = needed_tap_remotes
+            let tap_info_handles: Vec<(String, _)> = needed_tap_infos
                 .iter()
                 .cloned()
                 .map(|t| {
                     let key = t.clone();
-                    (key, s.spawn(move || fetch_tap_remote(&t)))
+                    (key, s.spawn(move || fetch_tap_info(&t)))
                 })
                 .collect();
 
@@ -198,7 +203,7 @@ impl PackageCache {
                     .map(|(m, h)| (m, join_probe(h)))
                     .collect();
             let taps_result = taps_handle.map(join_probe);
-            let tap_remote_results: Vec<(String, Result<Option<String>>)> = tap_remote_handles
+            let tap_info_results: Vec<(String, Result<Option<brew::TapInfo>>)> = tap_info_handles
                 .into_iter()
                 .map(|(t, h)| (t, join_probe(h)))
                 .collect();
@@ -206,7 +211,7 @@ impl PackageCache {
             ProbeResults {
                 installed_results,
                 taps_result,
-                tap_remote_results,
+                tap_info_results,
             }
         });
 
@@ -224,11 +229,11 @@ impl PackageCache {
             let set = r.context("listing installed brew taps (`brew tap`)")?;
             self.installed_taps = Some(set);
         }
-        for (t, r) in tap_remote_results {
-            let remote = r.with_context(|| {
-                format!("reading remote URL for tap `{t}` (`brew tap-info --json`)")
+        for (t, r) in tap_info_results {
+            let info = r.with_context(|| {
+                format!("reading remote URL for tap `{t}` (`brew tap-info --json=v1`)")
             })?;
-            self.tap_remotes.insert(t, remote);
+            self.tap_info.insert(t, info);
         }
 
         Ok(())
@@ -280,13 +285,17 @@ impl PackageCache {
 
     /// Classify a tap registration against the live state.
     ///
-    ///   - `Update` — tap is installed but its remote URL differs
-    ///     from the requested one. Only checked when the manifest
-    ///     declared a custom URL.
-    ///   - `NoOp` — tap is installed (URL matches, OR no URL was
-    ///     declared so any remote is acceptable), OR another tap
-    ///     resource in this plan already claimed a Create.
-    ///   - `Create` — tap isn't installed yet.
+    ///   - `Create` — tap isn't installed yet (the executor taps then
+    ///     trusts it).
+    ///   - `Update` — tap is installed but its remote URL differs from
+    ///     the requested one (checked only when the manifest declared a
+    ///     custom URL), OR the tap is installed but untrusted under brew
+    ///     6.0's tap-trust model. The executor re-taps (rewriting the
+    ///     remote when a URL drifted) then trusts.
+    ///   - `NoOp` — tap is installed, the remote matches (or no URL was
+    ///     declared), and it is trusted (or trust isn't enforced on this
+    ///     brew); OR another tap resource in this plan already claimed a
+    ///     Create.
     pub fn classify_tap(&mut self, spec: &TapSpec) -> Result<Action> {
         self.ensure_taps_loaded()?;
         let installed = self
@@ -301,15 +310,22 @@ impl PackageCache {
             self.scheduled_taps.insert(spec.user_tap.clone());
             return Ok(Action::Create);
         }
-        let Some(want_url) = spec.url.as_deref() else {
-            return Ok(Action::NoOp);
-        };
-        let actual = self.tap_remote(&spec.user_tap)?;
-        if actual.as_deref() == Some(want_url) {
-            Ok(Action::NoOp)
-        } else {
-            Ok(Action::Update)
+        let info = self.tap_info(&spec.user_tap)?;
+        // URL drift is only meaningful when the manifest declared a URL.
+        if let Some(want_url) = spec.url.as_deref() {
+            let actual = info.as_ref().and_then(|i| i.remote.as_deref());
+            if actual.map(brew::normalize_remote) != Some(brew::normalize_remote(want_url)) {
+                return Ok(Action::Update);
+            }
         }
+        // Brew 6.0 tap trust: an installed-but-untrusted tap needs an
+        // explicit `brew trust`. `trusted == None` (pre-6.0 brew, which
+        // doesn't enforce trust) is treated as satisfied so older brew
+        // never emits a spurious drift action.
+        if info.as_ref().and_then(|i| i.trusted) == Some(false) {
+            return Ok(Action::Update);
+        }
+        Ok(Action::NoOp)
     }
 
     fn ensure_installed_loaded(&mut self, manager: PackageManager) -> Result<()> {
@@ -339,16 +355,15 @@ impl PackageCache {
         Ok(())
     }
 
-    fn tap_remote(&mut self, user_tap: &str) -> Result<Option<String>> {
-        if let Some(cached) = self.tap_remotes.get(user_tap) {
+    fn tap_info(&mut self, user_tap: &str) -> Result<Option<brew::TapInfo>> {
+        if let Some(cached) = self.tap_info.get(user_tap) {
             return Ok(cached.clone());
         }
-        let remote = fetch_tap_remote(user_tap).with_context(|| {
-            format!("reading remote URL for tap `{user_tap}` (`brew tap-info --json`)")
+        let info = fetch_tap_info(user_tap).with_context(|| {
+            format!("reading remote URL for tap `{user_tap}` (`brew tap-info --json=v1`)")
         })?;
-        self.tap_remotes
-            .insert(user_tap.to_string(), remote.clone());
-        Ok(remote)
+        self.tap_info.insert(user_tap.to_string(), info.clone());
+        Ok(info)
     }
 }
 
@@ -364,7 +379,7 @@ fn bare_name(name: &str) -> &str {
 struct ProbeResults {
     installed_results: Vec<(PackageManager, Result<HashSet<String>>)>,
     taps_result: Option<Result<HashSet<String>>>,
-    tap_remote_results: Vec<(String, Result<Option<String>>)>,
+    tap_info_results: Vec<(String, Result<Option<brew::TapInfo>>)>,
 }
 
 /// Join a probe worker, surfacing a panic as a hard error rather than
@@ -409,11 +424,11 @@ fn fetch_taps() -> Result<HashSet<String>> {
     brew::fetch_taps()
 }
 
-fn fetch_tap_remote(user_tap: &str) -> Result<Option<String>> {
-    if let Some(remote) = test_tap_remote_override(user_tap) {
-        return Ok(remote);
+fn fetch_tap_info(user_tap: &str) -> Result<Option<brew::TapInfo>> {
+    if test_overrides_allowed() {
+        return Ok(Some(test_tap_info_override(user_tap)));
     }
-    brew::fetch_tap_remote(user_tap)
+    brew::fetch_tap_info(user_tap)
 }
 
 fn test_packages_override(manager: PackageManager) -> Option<HashSet<String>> {
@@ -438,11 +453,10 @@ fn test_taps_override() -> Option<HashSet<String>> {
     Some(parse_csv(&raw))
 }
 
-/// Test seam for `brew tap-info`. The env var format is
+/// Test seam for the tap `remote` field. The env var format is
 /// `user/repo=URL;user2/repo2=URL2`. An entry of `user/repo=` (empty
 /// value) maps to `Some(None)` — i.e. "tap is installed but has no
-/// known remote", which exercises the `None` arm of
-/// [`PackageCache::tap_remote`].
+/// known remote". Feeds [`test_tap_info_override`].
 #[allow(clippy::option_option)]
 fn test_tap_remote_override(user_tap: &str) -> Option<Option<String>> {
     if !test_overrides_allowed() {
@@ -465,6 +479,41 @@ fn test_tap_remote_override(user_tap: &str) -> Option<Option<String>> {
         }
     }
     None
+}
+
+/// Test seam for the tap `trusted` field (brew 6.0). The env var format
+/// is `user/repo=true;user2/repo2=false`. Absent entry → `None` so the
+/// caller can apply a sane default.
+fn test_tap_trusted_override(user_tap: &str) -> Option<bool> {
+    if !test_overrides_allowed() {
+        return None;
+    }
+    let raw = std::env::var("KERON_TEST_BREW_TAP_TRUSTED").ok()?;
+    for entry in raw.split(';') {
+        let entry = entry.trim();
+        if entry.is_empty() {
+            continue;
+        }
+        let Some((key, val)) = entry.split_once('=') else {
+            continue;
+        };
+        if key.trim() == user_tap {
+            return Some(val.trim() == "true");
+        }
+    }
+    None
+}
+
+/// Combine the remote and trusted seams into a [`brew::TapInfo`] for
+/// the test path. When neither seam mentions `user_tap`, trusted still
+/// defaults to `Some(true)` so existing tap tests (which never set the
+/// trust seam) keep classifying as `NoOp` rather than falling through to
+/// a real `brew` shell-out.
+fn test_tap_info_override(user_tap: &str) -> brew::TapInfo {
+    brew::TapInfo {
+        remote: test_tap_remote_override(user_tap).flatten(),
+        trusted: Some(test_tap_trusted_override(user_tap).unwrap_or(true)),
+    }
 }
 
 fn parse_csv(raw: &str) -> HashSet<String> {
@@ -561,16 +610,18 @@ fn install_many_with_stdio(
 fn spawn_batch(binary: &str, args: &[String], stdio: BatchStdio) -> Result<BatchOutput> {
     let mut cmd = Command::new(binary);
     cmd.args(args);
-    // Match the probe path's `HOMEBREW_NO_AUTO_UPDATE=1`: without it an
-    // install can kick off an implicit `brew update`, and when the
-    // formula and cask phases run concurrently both may do so at once —
-    // maximizing contention on brew's global lock and producing flaky
-    // "Another active Homebrew process is already in progress" failures.
+    // brew-only env: NO_AUTO_UPDATE prevents an install kicking off an
+    // implicit `brew update` that races the concurrent install phase for
+    // brew's global lock ("Another active Homebrew process is already in
+    // progress"); NO_ASK skips brew 6.0's new install confirmation
+    // prompt, which would stall the inherit path and EOF-abort the
+    // capture path. Centralised in `brew::apply_brew_env` so probes,
+    // taps, trusts and installs can't drift.
     if std::path::Path::new(binary)
         .file_name()
         .is_some_and(|n| n == "brew")
     {
-        cmd.env("HOMEBREW_NO_AUTO_UPDATE", "1");
+        brew::apply_brew_env(&mut cmd);
     }
     match stdio {
         BatchStdio::Inherit => {
@@ -608,16 +659,42 @@ fn spawn_batch(binary: &str, args: &[String], stdio: BatchStdio) -> Result<Batch
     }
 }
 
-/// Register a homebrew tap. Idempotent on brew's side, but callers
-/// typically gate this on [`PackageCache::classify_tap`] returning
-/// Create or Update so it doesn't shell out when the tap is already
-/// configured correctly.
-pub fn tap(spec: &TapSpec, action: Action) -> Result<()> {
+/// Register and trust a homebrew tap. Idempotent on brew's side, but
+/// callers typically gate this on [`PackageCache::classify_tap`]
+/// returning Create or Update so it doesn't shell out when the tap is
+/// already configured correctly and trusted.
+///
+/// `--custom-remote` is only passed when a URL was declared and the
+/// planner reported drift; an Update purely for trust (no URL) re-taps
+/// plainly then trusts. Every tap keron manages is also
+/// `brew trust`-ed so brew 6.0's tap-trust model stays satisfied.
+///
+/// Trust is best-effort: a `brew trust` failure is recorded as a
+/// [`Warning::TapUntrusted`] in `warnings` rather than propagated,
+/// because fully-qualified installs already auto-trust per-item on
+/// brew 6.0 — so a transient `trust.json` failure (locked file,
+/// permissions) must not abort the apply and block dependent installs
+/// that would otherwise succeed. The caller spills the collected
+/// warnings to the user after the run. The tap registration itself
+/// (`do_tap`) remains fatal: without it the dependent installs
+/// genuinely cannot work.
+pub fn tap(
+    spec: &TapSpec,
+    action: Action,
+    warnings: &mut Vec<crate::execute::Warning>,
+) -> Result<()> {
     if let Some(url) = spec.url.as_deref() {
         brew::validate_tap_url(url)?;
     }
-    let custom_remote = matches!(action, Action::Update);
-    brew::do_tap(&spec.user_tap, spec.url.as_deref(), custom_remote)
+    let custom_remote = matches!(action, Action::Update) && spec.url.is_some();
+    brew::do_tap(&spec.user_tap, spec.url.as_deref(), custom_remote)?;
+    if let Err(error) = brew::do_trust(&spec.user_tap) {
+        warnings.push(crate::execute::Warning::TapUntrusted {
+            user_tap: spec.user_tap.clone(),
+            error: format!("{error:#}"),
+        });
+    }
+    Ok(())
 }
 
 pub fn validate_package_manager_supported(manager: PackageManager, os: OsFamily) -> Result<()> {
@@ -889,7 +966,7 @@ mod tests {
         cache.prewarm(&resources).unwrap();
         assert!(cache.installed.is_empty());
         assert!(cache.installed_taps.is_none());
-        assert!(cache.tap_remotes.is_empty());
+        assert!(cache.tap_info.is_empty());
     }
 
     #[test]
@@ -922,12 +999,12 @@ mod tests {
     }
 
     #[test]
-    fn prewarm_loads_tap_remotes_for_url_qualified_taps_even_with_no_packages() {
-        // Companion of the above: with the second `&&` on line 157
-        // flipped to `||`, the `needed_tap_remotes` branch is bypassed
-        // when both packages and taps are already cached. Force a probe
-        // by supplying a URL-qualified tap and an env seam, then assert
-        // the per-tap remote memo got populated.
+    fn prewarm_loads_tap_info_for_taps_even_with_no_packages() {
+        // Companion of the above: with the second `&&` on the early
+        // return flipped to `||`, the `needed_tap_infos` branch is
+        // bypassed when both packages and taps are already cached.
+        // Force a probe by supplying a URL-qualified tap and an env
+        // seam, then assert the per-tap info memo got populated.
         let _g = lock_env();
         set_env("KERON_TEST_BREW_TAPS", "icepuma/keron");
         set_env(
@@ -935,12 +1012,12 @@ mod tests {
             "icepuma/keron=https://github.com/icepuma/keron",
         );
         // Pre-load installed_taps so `need_taps` is false; only the
-        // tap-remote slot still needs probing.
+        // tap-info slot still needs probing.
         let resources_pre = vec![tap_state("icepuma/keron", None)];
         let mut cache = PackageCache::for_tests();
         cache.prewarm(&resources_pre).unwrap();
         // Now prewarm with a URL-qualified tap. needed_installed is
-        // empty, need_taps is false, needed_tap_remotes has one entry.
+        // empty, need_taps is false, needed_tap_infos has one entry.
         let resources = vec![tap_state(
             "icepuma/keron",
             Some("https://github.com/icepuma/keron"),
@@ -948,8 +1025,8 @@ mod tests {
         cache.prewarm(&resources).unwrap();
         clear_env(&["KERON_TEST_BREW_TAPS", "KERON_TEST_BREW_TAP_REMOTES"]);
         assert!(
-            cache.tap_remotes.contains_key("icepuma/keron"),
-            "prewarm must probe the tap remote when only that slot is pending",
+            cache.tap_info.contains_key("icepuma/keron"),
+            "prewarm must probe the tap info when only that slot is pending",
         );
     }
 
@@ -1149,6 +1226,67 @@ mod tests {
     }
 
     #[test]
+    fn classify_tap_treats_git_suffix_difference_as_noop() {
+        // Brew 6.0 ignores a trailing `.git` when matching GitHub
+        // remotes, so a manifest URL with `.git` and an installed remote
+        // without it (or vice versa) must NOT classify as drift —
+        // otherwise every apply would re-tap.
+        let _g = lock_env();
+        set_env("KERON_TEST_BREW_TAPS", "icepuma/keron");
+        set_env(
+            "KERON_TEST_BREW_TAP_REMOTES",
+            "icepuma/keron=https://github.com/icepuma/keron",
+        );
+        let mut cache = PackageCache::for_tests();
+        let spec = TapSpec {
+            user_tap: "icepuma/keron".into(),
+            url: Some("https://github.com/icepuma/keron.git".into()),
+        };
+        let action = cache.classify_tap(&spec).unwrap();
+        clear_env(&["KERON_TEST_BREW_TAPS", "KERON_TEST_BREW_TAP_REMOTES"]);
+        assert_eq!(action, Action::NoOp);
+    }
+
+    #[test]
+    fn classify_tap_returns_update_when_untrusted() {
+        // Brew 6.0 tap trust: an installed-but-untrusted tap needs an
+        // explicit `brew trust`, so classify it as Update (the executor
+        // re-taps idempotently then trusts).
+        let _g = lock_env();
+        set_env("KERON_TEST_BREW_TAPS", "icepuma/keron");
+        set_env("KERON_TEST_BREW_TAP_TRUSTED", "icepuma/keron=false");
+        let mut cache = PackageCache::for_tests();
+        let spec = TapSpec {
+            user_tap: "icepuma/keron".into(),
+            url: None,
+        };
+        let action = cache.classify_tap(&spec).unwrap();
+        clear_env(&["KERON_TEST_BREW_TAPS", "KERON_TEST_BREW_TAP_TRUSTED"]);
+        assert_eq!(
+            action,
+            Action::Update,
+            "installed-but-untrusted tap must classify Update",
+        );
+    }
+
+    #[test]
+    fn classify_tap_returns_noop_when_trusted_unset() {
+        // The trust seam defaults to trusted when unset, so taps
+        // installed under pre-6.0 brew (no `trusted` field) stay NoOp
+        // instead of churning every apply.
+        let _g = lock_env();
+        set_env("KERON_TEST_BREW_TAPS", "icepuma/keron");
+        let mut cache = PackageCache::for_tests();
+        let spec = TapSpec {
+            user_tap: "icepuma/keron".into(),
+            url: None,
+        };
+        let action = cache.classify_tap(&spec).unwrap();
+        clear_env(&["KERON_TEST_BREW_TAPS"]);
+        assert_eq!(action, Action::NoOp);
+    }
+
+    #[test]
     fn classify_tap_dedup_in_same_run_returns_noop_on_repeat() {
         let _g = lock_env();
         set_env("KERON_TEST_BREW_TAPS", "");
@@ -1170,6 +1308,58 @@ mod tests {
         assert_eq!(bare_name("ripgrep"), "ripgrep");
         assert_eq!(bare_name("icepuma/keron/keron"), "keron");
         assert_eq!(bare_name("fluxcd/tap/flux"), "flux");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn tap_collects_warning_when_trust_fails_and_still_succeeds() {
+        // Trust is best-effort: a failed `brew trust` must NOT abort the
+        // apply (fully-qualified installs auto-trust per-item on brew
+        // 6.0). Instead tap() records a typed `Warning::TapUntrusted` so
+        // the caller can spill it to the user. The `brew tap` itself
+        // succeeds; only trust fails.
+        use std::os::unix::fs::PermissionsExt;
+        let _g = lock_env();
+        let dir = std::env::temp_dir().join(format!(
+            "keron-tap-trust-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map_or(0, |d| d.subsec_nanos()),
+        ));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let spy = dir.join("brew.sh");
+        std::fs::write(
+            &spy,
+            "#!/bin/sh\ncase \"$1\" in\n  tap) exit 0 ;;\n  trust) printf '%s\\n' 'Error: trust.json locked' >&2; exit 1 ;;\n  *) printf 'unexpected subcommand: %s\\n' \"$1\" >&2; exit 1 ;;\nesac\n",
+        )
+        .unwrap();
+        std::fs::set_permissions(&spy, std::fs::Permissions::from_mode(0o755)).unwrap();
+        set_env("KERON_TEST_PACKAGE_BIN_BREW", spy.to_str().unwrap());
+        let spec = TapSpec {
+            user_tap: "icepuma/keron".into(),
+            url: None,
+        };
+        let mut warnings: Vec<crate::execute::Warning> = Vec::new();
+        let result = tap(&spec, Action::Create, &mut warnings);
+        clear_env(&["KERON_TEST_PACKAGE_BIN_BREW"]);
+        let _ = std::fs::remove_dir_all(&dir);
+        result.expect("tap() must succeed even when brew trust fails (best-effort)");
+        assert_eq!(
+            warnings.len(),
+            1,
+            "exactly one warning expected, got: {warnings:?}"
+        );
+        match &warnings[0] {
+            crate::execute::Warning::TapUntrusted { user_tap, error } => {
+                assert_eq!(user_tap, "icepuma/keron");
+                assert!(
+                    error.contains("trust"),
+                    "warning error should mention trust, got: {error}",
+                );
+            }
+        }
     }
 
     #[test]

--- a/crates/keron-apply/src/plan.rs
+++ b/crates/keron-apply/src/plan.rs
@@ -528,8 +528,12 @@ fn synthesize_taps(resources: &[ResourceState]) -> Result<Vec<ResourceState>> {
                         // A second mention with a custom URL upgrades
                         // a previously bare tap declaration.
                         (None, Some(_)) => existing.url.clone_from(&spec.url),
-                        // Same URL or both bare → no-op.
-                        (Some(a), Some(b)) if a == b => {}
+                        // Equivalent URLs (after brew 6.0 `.git` /
+                        // trailing-slash normalisation) or both bare
+                        // → no-op.
+                        (Some(a), Some(b))
+                            if crate::packages::brew::normalize_remote(a)
+                                == crate::packages::brew::normalize_remote(b) => {}
                         (None | Some(_), None) => {}
                         // Two different custom URLs for the same tap
                         // is almost certainly a manifest bug.

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
 channel = "1.95.0"
-components = ["rustfmt", "clippy"]
+components = ["rustfmt", "clippy", "rust-analyzer"]
 profile = "minimal"


### PR DESCRIPTION
## Summary

Adapts `keron apply`'s Homebrew integration so it keeps working on **Homebrew 6.0** while staying compatible with older brew. Also pins `rust-analyzer` in the toolchain so editor/LSP integrations resolve against the project's toolchain.

## Motivation

Homebrew 6.0.0 (2026-06-11) shipped two behaviours that broke the existing integration:

- **Tap trust** — non-official taps must now be explicitly trusted before their formulae/casks load. keron synthesizes a `Tap` resource from `brew("user/tap/formula")` and runs `brew tap`; on 6.x that tap is untrusted, so `brew doctor` complains and bare-name installs from it fail.
- **`ask` mode is the default** for `brew install` — keron's installs run with inherited/captured stdio, so the prompt would stall the inherit path and EOF-abort the capture path.

## Changes

### `feat(apply): support Homebrew 6.0 tap trust and ask prompt`
- **`HOMEBREW_NO_ASK=1`** on every brew subprocess via a centralized `brew::apply_brew_env` (probes, `do_tap`, `do_trust`, installs). `do_tap` previously set *no* env vars and could auto-update mid-apply, racing the concurrent install phase.
- **Tap trust lifecycle**: `brew::do_trust` runs `brew trust --tap user/repo` after tapping. `classify_tap` classifies installed-but-untrusted taps as `Update` (covering the 6.0-upgrade path where pre-existing taps are installed-but-untrusted). `do_trust` tolerates pre-5.1.15 brew's "unknown command" but propagates real errors.
- **`.git`/trailing-slash normalization** (`brew::normalize_remote`) for tap-remote comparison — brew 6.0 ignores these when matching GitHub remotes; the old exact compare caused a spurious re-tap every apply. Applied in `classify_tap` and `synthesize_taps` (no more false "conflicting URLs" errors).
- **Best-effort trust with typed warnings**: a failed `brew trust` no longer aborts the apply (which would block dependent installs despite fully-qualified installs auto-trusting per-item on 6.0). New `execute::Warning` enum (`TapUntrusted { user_tap, error }`) is threaded through the apply path onto `ExecuteSummary.warnings` and spilled to the user in `run_with_io`. No `eprintln!` — warnings are collected objects.
- `brew tap-info --json=v1` now feeds both `remote` and the new `trusted` field.

### `build(toolchain): add rust-analyzer component`
- Adds `rust-analyzer` to `rust-toolchain.toml` components so the rustup proxy resolves it for the pinned `1.95.0` toolchain (otherwise: `Unknown binary 'rust-analyzer'`), enabling editor/LSP integrations.

## Verification
- `just` green: fmt + clippy `-D warnings` + **1549 tests pass** (added: `do_trust` ok/tolerates-unknown/bails-on-real-error, `.git`-equivalence → NoOp, untrusted → Update, `tap_collects_warning_when_trust_fails_and_still_succeeds`, `normalize_remote` cases).
- Checked against the real **brew 6.0.1** install: `brew tap-info` exits 0 for not-installed taps (so probing all taps in prewarm is safe); an installed-untrusted tap (`intar-dev/intar-dev`) really returns `trusted:false`; `.git`/slash normalization is sufficient since brew stores the remote verbatim.

## Notes
- `ExecuteSummary` lost `Copy` (now carries `Vec<Warning>`).
- This is a language/IR-adjacent behavior change; per `AGENTS.md`, the manual **mutants workflow** (`.github/workflows/mutants.yml`) is worth running before merge to confirm the new tests pin behavior.

🤖 Generated with [opencode](https://opencode.ai)
