### PR TITLE
feat: keron language server (`keron lsp`) + VS Code & Zed extensions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,10 +38,16 @@ crates/
   keron-lang/         lexer, parser, type checker, formatter        (lib)
   keron-modules/      module graph, `use` resolution, embedded stdlib (lib)
   keron-apply/        eval, plan, execute, elevation, providers, Tera (lib)
+  keron-lsp/          language server (`keron lsp`, lsp-server stdio) (lib)
   keron-cli/          thin orchestrator binary                      (bin)
+editors/
+  vscode/             VS Code extension (TS, spawns `keron lsp`)
+  zed/                Zed extension (wasm32-wasip1, outside the workspace)
 ```
 
 Add new crates under `crates/`. Keep each crate single-responsibility.
+`editors/zed` is `workspace.exclude`d — it has its own toolchain and
+lockfile and is compiled by Zed itself; never add it as a member.
 
 ## File size & modularization
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -124,6 +124,12 @@ checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
 version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
@@ -358,6 +364,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-channel"
+version = "0.5.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d85363c37faeca707aef026efa9f3b34d077bce547e48f770770625c6013679e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
+
+[[package]]
 name = "crypto-common"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -404,7 +425,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "objc2",
 ]
 
@@ -459,6 +480,15 @@ name = "fixedbitset"
 version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
+
+[[package]]
+name = "fluent-uri"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17c704e9dbe1ddd863da1e6ff3567795087b1eb201ce80d8fa81162e1516500d"
+dependencies = [
+ "bitflags 1.3.2",
+]
 
 [[package]]
 name = "fnv"
@@ -607,6 +637,7 @@ dependencies = [
  "clap",
  "keron-apply",
  "keron-lang",
+ "keron-lsp",
  "mutants",
  "similar 3.1.1",
 ]
@@ -622,6 +653,20 @@ dependencies = [
  "proptest",
  "stacker",
  "thiserror",
+]
+
+[[package]]
+name = "keron-lsp"
+version = "0.5.3"
+dependencies = [
+ "anyhow",
+ "keron-lang",
+ "keron-modules",
+ "lsp-server",
+ "lsp-types",
+ "proptest",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -678,6 +723,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
+name = "lsp-server"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ad8be6fe0ca81b8298bfbbe8a77e9fcd8895ad6c84cd7794d5ebadcbb09ae43"
+dependencies = [
+ "crossbeam-channel",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+]
+
+[[package]]
+name = "lsp-types"
+version = "0.97.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53353550a17c04ac46c585feb189c2db82154fc84b79c7a66c96c2c644f66071"
+dependencies = [
+ "bitflags 1.3.2",
+ "fluent-uri",
+ "serde",
+ "serde_json",
+ "serde_repr",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -695,7 +766,7 @@ version = "0.31.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -725,7 +796,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73ad74d880bb43877038da939b7427bba67e9dd42004a18b809ba7d87cee241c"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "objc2",
  "objc2-foundation",
 ]
@@ -746,7 +817,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "dispatch2",
  "objc2",
 ]
@@ -757,7 +828,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "dispatch2",
  "objc2",
  "objc2-core-foundation",
@@ -790,7 +861,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cde0dfb48d25d2b4862161a4d5fcc0e3c24367869ad306b0c9ec0073bfed92d"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "objc2",
  "objc2-core-foundation",
  "objc2-core-graphics",
@@ -808,7 +879,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "block2",
  "libc",
  "objc2",
@@ -821,7 +892,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "180788110936d59bab6bd83b6060ffdfffb3b922ba1396b312ae795e1de9d81d"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "objc2",
  "objc2-core-foundation",
 ]
@@ -832,7 +903,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96c1358452b371bf9f104e21ec536d37a650eb10f7ee379fff67d2e08d537f1f"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "objc2",
  "objc2-core-foundation",
  "objc2-foundation",
@@ -844,7 +915,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d87d638e33c06f577498cbcc50491496a3ed4246998a7fbba7ccb98b1e7eab22"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "block2",
  "objc2",
  "objc2-cloud-kit",
@@ -965,7 +1036,7 @@ checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
 dependencies = [
  "bit-set",
  "bit-vec",
- "bitflags",
+ "bitflags 2.13.0",
  "num-traits",
  "rand",
  "rand_chacha",
@@ -1094,7 +1165,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -1163,6 +1234,17 @@ dependencies = [
  "serde",
  "serde_core",
  "zmij",
+]
+
+[[package]]
+name = "serde_repr"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,11 @@ members = [
     "crates/keron-modules",
     "crates/keron-apply",
     "crates/keron-cli",
+    "crates/keron-lsp",
 ]
+# The Zed extension is its own wasm32-wasip1 crate with a separate
+# toolchain and lockfile; it must not join the native workspace build.
+exclude = ["editors/zed"]
 
 [workspace.package]
 version = "0.5.3"
@@ -22,6 +26,7 @@ shared-version = true
 keron-lang = { path = "crates/keron-lang" }
 keron-modules = { path = "crates/keron-modules" }
 keron-apply = { path = "crates/keron-apply" }
+keron-lsp = { path = "crates/keron-lsp" }
 
 chumsky = "=0.13.0"
 thiserror = "=2.0.18"
@@ -81,6 +86,15 @@ which = "=8.0.4"
 # diffs (template `content` and shell `script`) under the
 # `--verbose-will-reveal-sensitive-content` flag.
 similar = "=3.1.1"
+# Synchronous LSP transport + protocol types (the rust-analyzer
+# stack). Chosen over `tower-lsp` to avoid pulling an async runtime
+# into a workspace that has none; keron modules are small enough
+# that fully synchronous per-change analysis is the honest
+# architecture. lsp-types 0.97 backs `Uri` with `fluent-uri` (no
+# `url`/`idna` tree); file-path conversion lives in
+# `keron-lsp::uri`.
+lsp-server = "=0.8.0"
+lsp-types = "=0.97.0"
 # Stack-overflow defense for the user-fn call dispatch. Each
 # `eval_expr` → user-fn → `eval_block_value` recursion eats a Rust
 # stack frame; the depth guard at `MAX_CALL_DEPTH` is fine on the

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ keron apply ./manifest.keron --execute    # apply after confirmation
 keron check ./manifest.keron              # validate only: parse, resolve imports, type-check
 keron format ./manifest.keron             # normalize a file in place
 keron format . --check                    # verify formatting in CI
+keron lsp                                 # language server over stdio (spawned by editors)
 ```
 
 `<PATH>` may be a single `.keron` file or a directory of them (loaded in sorted
@@ -54,6 +55,14 @@ order).
 `keron check` is the cheap CI/editor path: it never resolves secrets or probes
 package managers. `keron format` writes in place (like `cargo fmt`) — pass
 `--check` for a dry-run diff; `apply` is the reverse, plan-first by default.
+
+## Editor support
+
+`keron lsp` is a built-in language server: diagnostics as you type,
+hover, completion, go-to-definition, formatting, and semantic
+highlighting in any LSP-capable editor. Setup snippets for Neovim,
+Helix, VS Code, Zed, Emacs, and Kakoune live in
+[docs/editors.md](docs/editors.md).
 
 ## The language at a glance
 

--- a/crates/keron-cli/Cargo.toml
+++ b/crates/keron-cli/Cargo.toml
@@ -15,6 +15,7 @@ path = "src/main.rs"
 [dependencies]
 keron-lang.workspace = true
 keron-apply.workspace = true
+keron-lsp.workspace = true
 
 anyhow.workspace = true
 clap.workspace = true

--- a/crates/keron-cli/src/main.rs
+++ b/crates/keron-cli/src/main.rs
@@ -88,6 +88,16 @@ enum Command {
         quiet: bool,
     },
 
+    /// Run a Language Server Protocol server over stdio for editor
+    /// integration.
+    ///
+    /// Editors spawn this (`command = "keron", args = ["lsp"]`) and
+    /// speak JSON-RPC over stdin/stdout: diagnostics, hover,
+    /// completion, go-to-definition, formatting, document symbols,
+    /// signature help, and semantic-token highlighting. Never run it
+    /// by hand — without a client it just waits on stdin.
+    Lsp,
+
     /// Internal: invoked by the unprivileged keron process under
     /// sudo / `ShellExecuteExW` to apply the subset of a plan that
     /// requires elevated rights. Reads the work payload from the
@@ -252,6 +262,10 @@ where
             let target = resolve_format_target(paths)?;
             run_format(target, check, quiet, &mut stdin.lock(), &mut stdout.lock())
                 .map_err(CliError::from)
+        }
+        Command::Lsp => {
+            keron_lsp::run_stdio_server()?;
+            Ok(ExitCode::SUCCESS)
         }
         Command::ApplyElevated {
             payload,
@@ -648,6 +662,19 @@ mod tests {
         let err =
             run_cli(["keron", "check", bad.to_str().unwrap()]).expect_err("type error must fail");
         assert_eq!(err.exit_code, 2, "a type error is a pre-apply failure");
+    }
+
+    /// Parse-level only: dispatching `lsp` would block on stdin
+    /// waiting for an LSP client, so pin the clap wiring instead.
+    #[test]
+    fn cli_parses_lsp_subcommand() {
+        use clap::Parser as _;
+        let cli = Cli::try_parse_from(["keron", "lsp"]).expect("`keron lsp` must parse");
+        assert!(matches!(cli.command, Command::Lsp));
+        assert!(
+            Cli::try_parse_from(["keron", "lsp", "--nonsense"]).is_err(),
+            "`lsp` takes no flags"
+        );
     }
 
     #[test]

--- a/crates/keron-lang/src/lib.rs
+++ b/crates/keron-lang/src/lib.rs
@@ -6,6 +6,7 @@ pub mod diagnostic;
 pub mod format;
 pub mod lex;
 pub mod parser;
+pub mod tokens;
 pub mod trivia;
 
 pub use ast::{
@@ -22,6 +23,7 @@ pub use diagnostic::Diagnostic;
 pub use format::format;
 pub use lex::{MultilineClose, is_multiline_close, multiline_open, raw_multiline_open_at};
 pub use parser::parse;
+pub use tokens::{LexToken, LexTokenKind, lex_tokens};
 pub use trivia::extract_comments;
 
 /// Parse `src` and additionally extract every comment, attached to

--- a/crates/keron-lang/src/tokens.rs
+++ b/crates/keron-lang/src/tokens.rs
@@ -1,0 +1,524 @@
+//! Error-tolerant lexical scanner for editor tooling.
+//!
+//! The chumsky grammar consumes `&str` directly and never materializes
+//! a token stream, which is fine for parsing but useless for syntax
+//! highlighting: a half-typed buffer has no AST, yet an editor still
+//! wants keywords and strings colored. [`lex_tokens`] fills that gap —
+//! it never fails, never panics, and degrades gracefully on broken
+//! input (an unterminated string simply ends at the line break or
+//! end of file).
+//!
+//! The scanner deliberately re-implements the *lexical* surface of the
+//! grammar (comments, the three string forms, numbers, identifiers,
+//! operators) instead of reusing parser combinators: it must survive
+//! inputs the parser rejects. Interpolation is scanned structurally —
+//! `"a${f(x)}b"` yields real tokens for `f`, `(`, `x`, `)` between the
+//! string segments — so highlighting inside `${…}` works.
+
+use crate::ast::Span;
+
+/// Lexical class of one scanned token. Coarser than the parser's
+/// grammar — just enough to drive syntax highlighting.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LexTokenKind {
+    /// `# …` to end of line.
+    Comment,
+    /// A string literal, or one contiguous segment of a string that is
+    /// interrupted by `${…}` interpolations. Quotes are included in
+    /// the adjacent segment's span.
+    Str,
+    /// Integer or double literal.
+    Number,
+    /// Reserved keyword (`val`, `fn`, `if`, …) or the contextual
+    /// import keywords `from` / `use`, plus `true` / `false` / `null`.
+    Keyword,
+    /// Reserved builtin type name: `String`, `Int`, `Boolean`,
+    /// `Double`, `List`, `Map`, `Void`.
+    BuiltinType,
+    /// Any other identifier.
+    Ident,
+    /// Operator such as `==`, `??`, `+`, `|`.
+    Operator,
+    /// Structural punctuation: `(){}[],:` and the `${` / `}` around
+    /// an interpolation.
+    Punct,
+}
+
+/// One token produced by [`lex_tokens`]. Spans are byte offsets into
+/// the scanned source and always lie on `char` boundaries.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LexToken {
+    pub kind: LexTokenKind,
+    pub span: Span,
+}
+
+/// Matches the parser's reserved words in `parser/util.rs`, plus the
+/// contextual `from` / `use` — those are legal identifiers in the
+/// grammar, but in practice they only appear as import keywords and
+/// highlighting them as such is the useful default.
+const KEYWORDS: &[&str] = &[
+    "val",
+    "fn",
+    "reconcile",
+    "if",
+    "else",
+    "for",
+    "in",
+    "match",
+    "struct",
+    "type",
+    "true",
+    "false",
+    "null",
+    "from",
+    "use",
+];
+
+const BUILTIN_TYPES: &[&str] = &["String", "Int", "Boolean", "Double", "List", "Map", "Void"];
+
+/// Deeper `"…${"…${…}…"}…"` nesting than this is scanned as plain
+/// string content. Bounds the scanner's recursion on adversarial
+/// input; the parser's own nesting limit is 256, so real programs
+/// never get close.
+const MAX_INTERPOLATION_DEPTH: usize = 32;
+
+/// Scan `src` into a flat, ordered token list. Whitespace and
+/// unrecognized characters produce no token; every returned span is
+/// non-empty and the list is sorted by start offset.
+#[must_use]
+pub fn lex_tokens(src: &str) -> Vec<LexToken> {
+    let mut scanner = Scanner {
+        src,
+        pos: 0,
+        depth: 0,
+        out: Vec::new(),
+    };
+    while let Some(c) = scanner.peek() {
+        if c.is_whitespace() {
+            scanner.bump(c);
+        } else {
+            scanner.scan_token(c);
+        }
+    }
+    scanner.out
+}
+
+struct Scanner<'s> {
+    src: &'s str,
+    pos: usize,
+    depth: usize,
+    out: Vec<LexToken>,
+}
+
+impl Scanner<'_> {
+    fn peek(&self) -> Option<char> {
+        self.src[self.pos..].chars().next()
+    }
+
+    const fn bump(&mut self, c: char) {
+        self.pos += c.len_utf8();
+    }
+
+    fn starts_with(&self, s: &str) -> bool {
+        self.src[self.pos..].starts_with(s)
+    }
+
+    fn push(&mut self, kind: LexTokenKind, start: usize) {
+        if self.pos > start {
+            self.out.push(LexToken {
+                kind,
+                span: start..self.pos,
+            });
+        }
+    }
+
+    fn scan_token(&mut self, c: char) {
+        match c {
+            '#' => self.comment(),
+            '"' => self.cooked_string(self.starts_with("\"\"\"")),
+            'r' => {
+                if let Some(hashes) = self.raw_open_hashes() {
+                    self.raw_string(hashes);
+                } else {
+                    self.ident();
+                }
+            }
+            _ if c.is_ascii_digit() => self.number(),
+            _ if c.is_alphabetic() || c == '_' => self.ident(),
+            _ => self.operator_or_punct(c),
+        }
+    }
+
+    fn comment(&mut self) {
+        let start = self.pos;
+        while let Some(c) = self.peek() {
+            if c == '\n' {
+                break;
+            }
+            self.bump(c);
+        }
+        self.push(LexTokenKind::Comment, start);
+    }
+
+    /// Scan a cooked string (single-line `"…"` or multi-line
+    /// `"""…"""`), splitting around `${…}` interpolations so their
+    /// contents come out as real tokens.
+    fn cooked_string(&mut self, multiline: bool) {
+        let mut seg_start = self.pos;
+        self.pos += if multiline { 3 } else { 1 };
+        while let Some(c) = self.peek() {
+            if multiline {
+                if self.starts_with("\"\"\"") {
+                    self.pos += 3;
+                    break;
+                }
+            } else if c == '"' {
+                self.bump(c);
+                break;
+            } else if c == '\n' {
+                // Unterminated single-line string: stop at the line
+                // break instead of swallowing the rest of the buffer.
+                break;
+            }
+            if c == '\\' {
+                self.bump(c);
+                if let Some(escaped) = self.peek() {
+                    self.bump(escaped);
+                }
+                continue;
+            }
+            if self.starts_with("${") && self.depth < MAX_INTERPOLATION_DEPTH {
+                self.push(LexTokenKind::Str, seg_start);
+                self.interpolation();
+                seg_start = self.pos;
+                continue;
+            }
+            self.bump(c);
+        }
+        self.push(LexTokenKind::Str, seg_start);
+    }
+
+    /// Scan the `${…}` following a string segment. Brace depth is
+    /// tracked so map literals inside the interpolation don't end it
+    /// early.
+    fn interpolation(&mut self) {
+        let start = self.pos;
+        self.pos += 2;
+        self.push(LexTokenKind::Punct, start);
+        self.depth += 1;
+        let mut braces = 1usize;
+        while let Some(c) = self.peek() {
+            if c == '{' || c == '}' {
+                if c == '{' {
+                    braces += 1;
+                } else {
+                    braces -= 1;
+                }
+                let s = self.pos;
+                self.bump(c);
+                self.push(LexTokenKind::Punct, s);
+                if braces == 0 {
+                    break;
+                }
+            } else if c.is_whitespace() {
+                self.bump(c);
+            } else {
+                self.scan_token(c);
+            }
+        }
+        self.depth -= 1;
+    }
+
+    /// `Some(n)` when the scanner sits on a raw-string opener
+    /// `r#…#"""` with `n` hashes. Unlike `lex::raw_multiline_open_at`
+    /// this accepts same-line raw strings too — the scanner does not
+    /// care whether the close is on the same line.
+    fn raw_open_hashes(&self) -> Option<usize> {
+        let rest = self.src[self.pos..].strip_prefix('r')?;
+        let hashes = rest.bytes().take_while(|b| *b == b'#').count();
+        rest[hashes..].starts_with("\"\"\"").then_some(hashes)
+    }
+
+    fn raw_string(&mut self, hashes: usize) {
+        let start = self.pos;
+        self.pos += 1 + hashes + 3;
+        let close = format!("\"\"\"{}", "#".repeat(hashes));
+        match self.src[self.pos..].find(&close) {
+            Some(i) => self.pos += i + close.len(),
+            None => self.pos = self.src.len(),
+        }
+        self.push(LexTokenKind::Str, start);
+    }
+
+    fn number(&mut self) {
+        let start = self.pos;
+        self.eat_digits();
+        // `1.x` is a field access on `1`, not a malformed double, so
+        // only take the dot when a digit follows — same rule as the
+        // grammar's `int . digits` fraction.
+        let mut lookahead = self.src[self.pos..].chars();
+        if lookahead.next() == Some('.') && lookahead.next().is_some_and(|c| c.is_ascii_digit()) {
+            self.bump('.');
+            self.eat_digits();
+        }
+        self.push(LexTokenKind::Number, start);
+    }
+
+    fn eat_digits(&mut self) {
+        while let Some(c) = self.peek() {
+            if !c.is_ascii_digit() {
+                break;
+            }
+            self.bump(c);
+        }
+    }
+
+    fn ident(&mut self) {
+        let start = self.pos;
+        while let Some(c) = self.peek() {
+            if !(c.is_alphanumeric() || c == '_') {
+                break;
+            }
+            self.bump(c);
+        }
+        let text = &self.src[start..self.pos];
+        let kind = if KEYWORDS.contains(&text) {
+            LexTokenKind::Keyword
+        } else if BUILTIN_TYPES.contains(&text) {
+            LexTokenKind::BuiltinType
+        } else {
+            LexTokenKind::Ident
+        };
+        self.push(kind, start);
+    }
+
+    fn operator_or_punct(&mut self, c: char) {
+        const TWO_CHAR_OPS: &[&str] = &[
+            "->", "!=", "??", "**", "&&", "++", "<=", "==", "=>", ">=", "||",
+        ];
+        let start = self.pos;
+        for op in TWO_CHAR_OPS {
+            if self.starts_with(op) {
+                self.pos += op.len();
+                self.push(LexTokenKind::Operator, start);
+                return;
+            }
+        }
+        self.bump(c);
+        match c {
+            '+' | '-' | '*' | '/' | '%' | '<' | '>' | '=' | '!' | '?' | '.' | '|' | '&' => {
+                self.push(LexTokenKind::Operator, start);
+            }
+            '(' | ')' | '{' | '}' | '[' | ']' | ',' | ':' | ';' => {
+                self.push(LexTokenKind::Punct, start);
+            }
+            // Anything else (stray bytes in a broken buffer) produces
+            // no token; the bump above guarantees forward progress.
+            _ => {}
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn kinds(src: &str) -> Vec<(LexTokenKind, &str)> {
+        lex_tokens(src)
+            .into_iter()
+            .map(|t| (t.kind, &src[t.span]))
+            .collect()
+    }
+
+    #[test]
+    fn keywords_types_and_idents_classify() {
+        use LexTokenKind::{BuiltinType, Ident, Keyword, Operator, Punct};
+        assert_eq!(
+            kinds("val greeting: String = name"),
+            vec![
+                (Keyword, "val"),
+                (Ident, "greeting"),
+                (Punct, ":"),
+                (BuiltinType, "String"),
+                (Operator, "="),
+                (Ident, "name"),
+            ]
+        );
+    }
+
+    #[test]
+    fn contextual_import_keywords_classify_as_keywords() {
+        let toks = kinds("from \"./lib.keron\" use helper");
+        assert_eq!(toks[0], (LexTokenKind::Keyword, "from"));
+        assert_eq!(toks[1], (LexTokenKind::Str, "\"./lib.keron\""));
+        assert_eq!(toks[2], (LexTokenKind::Keyword, "use"));
+        assert_eq!(toks[3], (LexTokenKind::Ident, "helper"));
+    }
+
+    #[test]
+    fn comment_runs_to_end_of_line_only() {
+        assert_eq!(
+            kinds("# hello\nval"),
+            vec![
+                (LexTokenKind::Comment, "# hello"),
+                (LexTokenKind::Keyword, "val"),
+            ]
+        );
+    }
+
+    #[test]
+    fn hash_inside_string_is_not_a_comment() {
+        assert_eq!(kinds("\"a # b\""), vec![(LexTokenKind::Str, "\"a # b\"")]);
+    }
+
+    #[test]
+    fn numbers_split_int_and_double() {
+        assert_eq!(
+            kinds("1 2.5"),
+            vec![(LexTokenKind::Number, "1"), (LexTokenKind::Number, "2.5")]
+        );
+    }
+
+    #[test]
+    fn dot_without_digit_is_field_access_not_double() {
+        assert_eq!(
+            kinds("1.x"),
+            vec![
+                (LexTokenKind::Number, "1"),
+                (LexTokenKind::Operator, "."),
+                (LexTokenKind::Ident, "x"),
+            ]
+        );
+    }
+
+    #[test]
+    fn escaped_quote_does_not_close_string() {
+        assert_eq!(kinds(r#""a\"b""#), vec![(LexTokenKind::Str, r#""a\"b""#)]);
+    }
+
+    #[test]
+    fn unterminated_string_stops_at_line_break() {
+        assert_eq!(
+            kinds("\"open\nval x"),
+            vec![
+                (LexTokenKind::Str, "\"open"),
+                (LexTokenKind::Keyword, "val"),
+                (LexTokenKind::Ident, "x"),
+            ]
+        );
+    }
+
+    #[test]
+    fn interpolation_yields_inner_tokens() {
+        use LexTokenKind::{Ident, Punct, Str};
+        assert_eq!(
+            kinds("\"a${f(x)}b\""),
+            vec![
+                (Str, "\"a"),
+                (Punct, "${"),
+                (Ident, "f"),
+                (Punct, "("),
+                (Ident, "x"),
+                (Punct, ")"),
+                (Punct, "}"),
+                (Str, "b\""),
+            ]
+        );
+    }
+
+    #[test]
+    fn nested_braces_inside_interpolation_do_not_end_it() {
+        let toks = kinds("\"${ {\"k\": 1} }\"");
+        assert!(
+            toks.contains(&(LexTokenKind::Number, "1")),
+            "map value should tokenize: {toks:?}"
+        );
+        assert_eq!(*toks.last().unwrap(), (LexTokenKind::Str, "\""));
+    }
+
+    #[test]
+    fn escaped_dollar_is_not_interpolation() {
+        assert_eq!(
+            kinds(r#""a\${x}b""#),
+            vec![(LexTokenKind::Str, r#""a\${x}b""#)]
+        );
+    }
+
+    #[test]
+    fn multiline_cooked_string_scans_to_close() {
+        assert_eq!(
+            kinds("val s = \"\"\"\nline # not comment\n\"\"\""),
+            vec![
+                (LexTokenKind::Keyword, "val"),
+                (LexTokenKind::Ident, "s"),
+                (LexTokenKind::Operator, "="),
+                (LexTokenKind::Str, "\"\"\"\nline # not comment\n\"\"\""),
+            ]
+        );
+    }
+
+    #[test]
+    fn raw_string_close_requires_matching_hashes() {
+        let src = "r#\"\"\"body \"\"\" still body\"\"\"#";
+        assert_eq!(kinds(src), vec![(LexTokenKind::Str, src)]);
+    }
+
+    #[test]
+    fn unterminated_raw_string_runs_to_eof_without_panic() {
+        let src = "r##\"\"\"never closed";
+        assert_eq!(kinds(src), vec![(LexTokenKind::Str, src)]);
+    }
+
+    #[test]
+    fn identifier_starting_with_r_is_not_a_raw_string() {
+        assert_eq!(
+            kinds("reconciler"),
+            vec![(LexTokenKind::Ident, "reconciler")]
+        );
+    }
+
+    #[test]
+    fn two_char_operators_win_over_single() {
+        use LexTokenKind::Operator;
+        assert_eq!(
+            kinds("== != ?? ++ =>"),
+            vec![
+                (Operator, "=="),
+                (Operator, "!="),
+                (Operator, "??"),
+                (Operator, "++"),
+                (Operator, "=>"),
+            ]
+        );
+    }
+
+    #[test]
+    fn spans_are_sorted_nonempty_and_on_char_boundaries() {
+        let src = "val 你好 = \"héllo ${x} 🎉\" # done\nr#\"\"\"raw\"\"\"# 3.14 ??";
+        let toks = lex_tokens(src);
+        let mut prev_end = 0;
+        for t in &toks {
+            assert!(t.span.start < t.span.end, "empty span: {t:?}");
+            assert!(t.span.start >= prev_end, "overlap: {t:?}");
+            assert!(src.is_char_boundary(t.span.start));
+            assert!(src.is_char_boundary(t.span.end));
+            prev_end = t.span.end;
+        }
+        assert!(prev_end <= src.len());
+    }
+
+    #[test]
+    fn deep_interpolation_nesting_is_bounded_not_recursive_blowup() {
+        let mut src = String::new();
+        for _ in 0..200 {
+            src.push_str("\"${");
+        }
+        src.push('x');
+        for _ in 0..200 {
+            src.push_str("}\"");
+        }
+        // Must terminate without stack overflow; token content is
+        // best-effort beyond MAX_INTERPOLATION_DEPTH.
+        let _ = lex_tokens(&src);
+    }
+}

--- a/crates/keron-lsp/Cargo.toml
+++ b/crates/keron-lsp/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "keron-lsp"
+description = "Language Server Protocol implementation for keron"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+authors.workspace = true
+
+[dependencies]
+keron-lang.workspace = true
+keron-modules.workspace = true
+
+anyhow.workspace = true
+lsp-server.workspace = true
+lsp-types.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+
+[dev-dependencies]
+proptest.workspace = true
+
+[lints]
+workspace = true

--- a/crates/keron-lsp/src/analysis/mod.rs
+++ b/crates/keron-lsp/src/analysis/mod.rs
@@ -1,0 +1,100 @@
+//! Whole-workspace analysis: run the module resolver over every open
+//! document (overlaying unsaved buffer text over disk) and turn the
+//! per-module errors into `publishDiagnostics` payloads.
+
+pub mod node_at;
+pub mod symbols;
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::str::FromStr;
+
+use keron_modules::{DiskLoader, EntrySource, FileLoader, ModuleId, resolve_with_loader};
+use lsp_types::{PublishDiagnosticsParams, Uri};
+
+use crate::handlers::diagnostics::to_lsp;
+use crate::line_index::LineIndex;
+use crate::state::{Document, ServerState};
+use crate::uri::path_to_uri;
+
+/// [`FileLoader`] that prefers open-buffer text and falls back to
+/// disk, so `use`-imported modules see unsaved edits.
+struct OverlayLoader<'a> {
+    docs: &'a HashMap<PathBuf, Document>,
+}
+
+impl FileLoader for OverlayLoader<'_> {
+    fn read_to_string(&self, path: &Path) -> Result<String, String> {
+        if let Some(doc) = self.docs.get(path) {
+            return Ok(doc.text.clone());
+        }
+        DiskLoader.read_to_string(path)
+    }
+}
+
+/// Re-resolve all open documents, store the new [`keron_modules::Resolution`]
+/// on `state`, and return only the `publishDiagnostics` payloads that
+/// changed since the previous round (including empty payloads for
+/// URIs whose diagnostics disappeared).
+pub fn analyze(state: &mut ServerState) -> Vec<PublishDiagnosticsParams> {
+    let roots: Vec<EntrySource> = state
+        .docs
+        .iter()
+        .map(|(path, doc)| EntrySource {
+            text: doc.text.clone(),
+            base_dir: path.parent().map_or_else(PathBuf::new, Path::to_path_buf),
+            id: ModuleId(path.clone()),
+        })
+        .collect();
+    let resolution = resolve_with_loader(roots, &OverlayLoader { docs: &state.docs });
+
+    let mut fresh: HashMap<String, (Uri, Vec<lsp_types::Diagnostic>)> = HashMap::new();
+    for err in &resolution.errors {
+        let Some(uri) = path_to_uri(&err.module.0) else {
+            continue;
+        };
+        let source = resolution
+            .sources
+            .get(&err.module)
+            .map_or("", String::as_str);
+        let index = LineIndex::new(source);
+        let entry = fresh
+            .entry(uri.as_str().to_string())
+            .or_insert_with(|| (uri, Vec::new()));
+        for diag in &err.diagnostics {
+            entry.1.push(to_lsp(diag, source, &index));
+        }
+    }
+    for (_, diags) in fresh.values_mut() {
+        diags.sort_by_key(|d| (d.range.start, d.range.end));
+        diags.dedup();
+    }
+    state.resolution = Some(resolution);
+
+    let mut out = Vec::new();
+    for (uri_str, (uri, diags)) in &fresh {
+        if state.published.get(uri_str) != Some(diags) {
+            out.push(PublishDiagnosticsParams {
+                uri: uri.clone(),
+                diagnostics: diags.clone(),
+                version: None,
+            });
+        }
+    }
+    for uri_str in state.published.keys() {
+        if !fresh.contains_key(uri_str)
+            && let Ok(uri) = Uri::from_str(uri_str)
+        {
+            out.push(PublishDiagnosticsParams {
+                uri,
+                diagnostics: Vec::new(),
+                version: None,
+            });
+        }
+    }
+    state.published = fresh
+        .into_iter()
+        .map(|(k, (_, diags))| (k, diags))
+        .collect();
+    out
+}

--- a/crates/keron-lsp/src/analysis/node_at.rs
+++ b/crates/keron-lsp/src/analysis/node_at.rs
@@ -1,0 +1,565 @@
+//! Locate the AST node under a byte offset.
+//!
+//! [`node_at`] is the front door for hover / go-to-definition /
+//! signature help: given a parsed [`Program`] and a cursor offset it
+//! returns the most specific *interesting* node — identifier
+//! references, declaration names, type names, import items. Plain
+//! literals and structural punctuation return `None`; there is nothing
+//! to say about them.
+
+use keron_lang::{
+    Block, Expr, FnDecl, Param, Pattern, Program, Span, Spanned, Stmt, StructDecl, StructField,
+    Type, TypeAliasDecl, UseDecl, ValDecl,
+};
+
+/// The node found under the cursor. Reference-shaped variants carry
+/// what the handlers need to resolve them; declaration-shaped variants
+/// carry the whole declaration so hover can render it directly.
+#[derive(Debug)]
+pub enum NodeRef<'a> {
+    /// A call's callee or a struct literal's name — something invoked.
+    Callee(&'a Spanned<String>),
+    /// A `val`/param/binding reference (`Expr::Var` or a struct-literal
+    /// shorthand field).
+    Var {
+        name: &'a str,
+        span: Span,
+    },
+    /// The `field` of `receiver.field`.
+    FieldAccess {
+        receiver: &'a Spanned<Expr>,
+        field: &'a Spanned<String>,
+    },
+    /// A named type inside a type annotation (struct, string union, or
+    /// unresolved name), e.g. the `Point` of `List<Point>`.
+    TypeName {
+        name: &'a str,
+        span: Span,
+    },
+    FnName(&'a FnDecl),
+    ValName(&'a ValDecl),
+    StructName(&'a StructDecl),
+    TypeAliasName(&'a TypeAliasDecl),
+    ParamName(&'a Param),
+    StructFieldName(&'a StructField),
+    /// The quoted path of a `from "…" use …` item.
+    UsePath(&'a UseDecl),
+    /// One imported name of a `from "…" use …` item.
+    UseName {
+        name: &'a Spanned<String>,
+    },
+}
+
+const fn contains(span: &Span, offset: usize) -> bool {
+    span.start <= offset && offset < span.end
+}
+
+/// Find the most specific interesting node at `offset`.
+#[must_use]
+pub fn node_at(program: &Program, offset: usize) -> Option<NodeRef<'_>> {
+    program
+        .items
+        .iter()
+        .filter(|item| contains(&item.span(), offset))
+        .find_map(|item| item_at(item, offset))
+}
+
+fn item_at(item: &keron_lang::Item, offset: usize) -> Option<NodeRef<'_>> {
+    use keron_lang::Item;
+    match item {
+        Item::Use(u) => use_at(u, offset),
+        Item::Val(v) => val_at(v, offset),
+        Item::Fn(f) => fn_at(f, offset),
+        Item::Struct(s) => struct_at(s, offset),
+        Item::TypeAlias(t) => contains(&t.name.span, offset).then_some(NodeRef::TypeAliasName(t)),
+        Item::Reconcile(r) => r.chains.iter().flatten().find_map(|e| expr_at(e, offset)),
+        Item::ExprStmt(e) => expr_at(e, offset),
+    }
+}
+
+fn use_at(u: &UseDecl, offset: usize) -> Option<NodeRef<'_>> {
+    if contains(&u.source.span, offset) {
+        return Some(NodeRef::UsePath(u));
+    }
+    u.names
+        .iter()
+        .find(|n| contains(&n.span, offset))
+        .map(|name| NodeRef::UseName { name })
+}
+
+fn val_at(v: &ValDecl, offset: usize) -> Option<NodeRef<'_>> {
+    if contains(&v.name.span, offset) {
+        return Some(NodeRef::ValName(v));
+    }
+    if let Some(ty) = &v.ty
+        && let Some(found) = type_at(ty, offset)
+    {
+        return Some(found);
+    }
+    expr_at(&v.value, offset)
+}
+
+fn fn_at(f: &FnDecl, offset: usize) -> Option<NodeRef<'_>> {
+    if contains(&f.name.span, offset) {
+        return Some(NodeRef::FnName(f));
+    }
+    for p in &f.params {
+        if contains(&p.name.span, offset) {
+            return Some(NodeRef::ParamName(p));
+        }
+        if let Some(found) = type_at(&p.ty, offset) {
+            return Some(found);
+        }
+        if let Some(d) = &p.default
+            && let Some(found) = expr_at(d, offset)
+        {
+            return Some(found);
+        }
+    }
+    if let Some(found) = type_at(&f.return_type, offset) {
+        return Some(found);
+    }
+    block_at(&f.body, offset)
+}
+
+fn struct_at(s: &StructDecl, offset: usize) -> Option<NodeRef<'_>> {
+    if contains(&s.name.span, offset) {
+        return Some(NodeRef::StructName(s));
+    }
+    for field in &s.fields {
+        if contains(&field.name.span, offset) {
+            return Some(NodeRef::StructFieldName(field));
+        }
+        if let Some(found) = type_at(&field.ty, offset) {
+            return Some(found);
+        }
+        if let Some(d) = &field.default
+            && let Some(found) = expr_at(d, offset)
+        {
+            return Some(found);
+        }
+    }
+    None
+}
+
+/// A `Spanned<Type>` covers the whole annotation (`List<Point>` is one
+/// span), so report the *primary* named type inside it — the name a
+/// user would want to jump to.
+fn type_at(ty: &Spanned<Type>, offset: usize) -> Option<NodeRef<'_>> {
+    if !contains(&ty.span, offset) {
+        return None;
+    }
+    primary_named(&ty.node).map(|name| NodeRef::TypeName {
+        name,
+        span: ty.span.clone(),
+    })
+}
+
+fn primary_named(ty: &Type) -> Option<&str> {
+    match ty {
+        Type::Struct { name, .. } | Type::StringUnion { name, .. } | Type::Named(name) => {
+            Some(name)
+        }
+        Type::List(inner) | Type::Nullable(inner) => primary_named(inner),
+        Type::Map(k, v) => primary_named(v).or_else(|| primary_named(k)),
+        _ => None,
+    }
+}
+
+fn block_at(b: &Block, offset: usize) -> Option<NodeRef<'_>> {
+    if !contains(&b.span, offset) {
+        return None;
+    }
+    for stmt in &b.stmts {
+        let found = match stmt {
+            Stmt::Val(v) => val_at(v, offset),
+            Stmt::Reconcile(r) => r.chains.iter().flatten().find_map(|e| expr_at(e, offset)),
+            Stmt::Expr(e) => expr_at(e, offset),
+        };
+        if found.is_some() {
+            return found;
+        }
+    }
+    b.trailing.as_ref().and_then(|t| expr_at(t, offset))
+}
+
+fn expr_at(e: &Spanned<Expr>, offset: usize) -> Option<NodeRef<'_>> {
+    if !contains(&e.span, offset) {
+        return None;
+    }
+    match &e.node {
+        Expr::Literal(_) => None,
+        Expr::Unary { operand, .. } => expr_at(operand, offset),
+        Expr::Binary { lhs, rhs, .. } => expr_at(lhs, offset).or_else(|| expr_at(rhs, offset)),
+        Expr::Interpolation(parts) => parts.iter().find_map(|p| match p {
+            keron_lang::StringPart::Expr { expr, .. } => expr_at(expr, offset),
+            keron_lang::StringPart::Text(_) => None,
+        }),
+        Expr::List(items) => items.iter().find_map(|x| expr_at(x, offset)),
+        Expr::Map(entries) => entries
+            .iter()
+            .find_map(|en| expr_at(&en.key, offset).or_else(|| expr_at(&en.value, offset))),
+        Expr::Var(name) => Some(NodeRef::Var {
+            name,
+            span: e.span.clone(),
+        }),
+        Expr::Call { callee, args } => {
+            if contains(&callee.span, offset) {
+                return Some(NodeRef::Callee(callee));
+            }
+            args.iter().find_map(|a| expr_at(&a.value, offset))
+        }
+        Expr::StructLiteral { name, fields } => {
+            if contains(&name.span, offset) {
+                return Some(NodeRef::Callee(name));
+            }
+            fields.iter().find_map(|f| {
+                f.value.as_ref().map_or_else(
+                    // Shorthand `Name { field }` — the field name
+                    // doubles as a val reference.
+                    || {
+                        contains(&f.name.span, offset).then(|| NodeRef::Var {
+                            name: &f.name.node,
+                            span: f.name.span.clone(),
+                        })
+                    },
+                    |v| expr_at(v, offset),
+                )
+            })
+        }
+        Expr::If {
+            cond,
+            then_branch,
+            else_branch,
+        } => expr_at(cond, offset)
+            .or_else(|| block_at(then_branch, offset))
+            .or_else(|| block_at(else_branch, offset)),
+        Expr::For {
+            iter_expr, body, ..
+        } => expr_at(iter_expr, offset).or_else(|| block_at(body, offset)),
+        Expr::Field { receiver, field } => {
+            if let Some(found) = expr_at(receiver, offset) {
+                return Some(found);
+            }
+            contains(&field.span, offset).then_some(NodeRef::FieldAccess { receiver, field })
+        }
+        Expr::Match { scrutinee, arms } => expr_at(scrutinee, offset).or_else(|| {
+            arms.iter().find_map(|arm| {
+                pattern_at(&arm.pattern, offset)
+                    .or_else(|| arm.guard.as_ref().and_then(|g| expr_at(g, offset)))
+                    .or_else(|| expr_at(&arm.body, offset))
+            })
+        }),
+    }
+}
+
+fn pattern_at(p: &Spanned<Pattern>, offset: usize) -> Option<NodeRef<'_>> {
+    if !contains(&p.span, offset) {
+        return None;
+    }
+    match &p.node {
+        Pattern::Struct { name, fields } => {
+            if contains(&name.span, offset) {
+                return Some(NodeRef::TypeName {
+                    name: &name.node,
+                    span: name.span.clone(),
+                });
+            }
+            fields
+                .iter()
+                .find_map(|f| f.pattern.as_ref().and_then(|sub| pattern_at(sub, offset)))
+        }
+        Pattern::Lit(_) | Pattern::Wildcard | Pattern::Bind(_) => None,
+    }
+}
+
+/// The innermost call whose argument list contains `offset` — the
+/// inputs signature help needs.
+#[derive(Debug)]
+pub struct CallCtx<'a> {
+    pub callee: &'a Spanned<String>,
+    pub args: &'a [keron_lang::CallArg],
+    /// Zero-based index of the argument the cursor sits in (equals
+    /// `args.len()` when the cursor is past the last argument).
+    pub active: usize,
+}
+
+/// Find the innermost call whose argument-list region contains
+/// `offset`.
+#[must_use]
+pub fn enclosing_call(program: &Program, offset: usize) -> Option<CallCtx<'_>> {
+    let mut best: Option<(CallCtx<'_>, usize)> = None;
+    walk_exprs(program, &mut |e| {
+        if let Expr::Call { callee, args } = &e.node
+            && contains(&e.span, offset)
+            && offset >= callee.span.end
+        {
+            let width = e.span.end - e.span.start;
+            if best.as_ref().is_none_or(|&(_, w)| width <= w) {
+                let active = args.iter().take_while(|a| offset > a.span.end).count();
+                best = Some((
+                    CallCtx {
+                        callee,
+                        args,
+                        active,
+                    },
+                    width,
+                ));
+            }
+        }
+    });
+    best.map(|(ctx, _)| ctx)
+}
+
+/// Visit every expression node in the program, depth-first.
+pub fn walk_exprs<'a>(program: &'a Program, f: &mut impl FnMut(&'a Spanned<Expr>)) {
+    use keron_lang::Item;
+    for item in &program.items {
+        match item {
+            Item::Val(v) => walk_expr(&v.value, f),
+            Item::Fn(fun) => {
+                for p in &fun.params {
+                    if let Some(d) = &p.default {
+                        walk_expr(d, f);
+                    }
+                }
+                walk_block(&fun.body, f);
+            }
+            Item::Struct(s) => {
+                for field in &s.fields {
+                    if let Some(d) = &field.default {
+                        walk_expr(d, f);
+                    }
+                }
+            }
+            Item::Reconcile(r) => {
+                for e in r.chains.iter().flatten() {
+                    walk_expr(e, f);
+                }
+            }
+            Item::ExprStmt(e) => walk_expr(e, f),
+            Item::Use(_) | Item::TypeAlias(_) => {}
+        }
+    }
+}
+
+fn walk_block<'a>(b: &'a Block, f: &mut impl FnMut(&'a Spanned<Expr>)) {
+    for stmt in &b.stmts {
+        match stmt {
+            Stmt::Val(v) => walk_expr(&v.value, f),
+            Stmt::Reconcile(r) => {
+                for e in r.chains.iter().flatten() {
+                    walk_expr(e, f);
+                }
+            }
+            Stmt::Expr(e) => walk_expr(e, f),
+        }
+    }
+    if let Some(t) = &b.trailing {
+        walk_expr(t, f);
+    }
+}
+
+fn walk_expr<'a>(e: &'a Spanned<Expr>, f: &mut impl FnMut(&'a Spanned<Expr>)) {
+    f(e);
+    match &e.node {
+        Expr::Literal(_) | Expr::Var(_) => {}
+        Expr::Unary { operand, .. } => walk_expr(operand, f),
+        Expr::Binary { lhs, rhs, .. } => {
+            walk_expr(lhs, f);
+            walk_expr(rhs, f);
+        }
+        Expr::Interpolation(parts) => {
+            for p in parts {
+                if let keron_lang::StringPart::Expr { expr, .. } = p {
+                    walk_expr(expr, f);
+                }
+            }
+        }
+        Expr::List(items) => {
+            for x in items {
+                walk_expr(x, f);
+            }
+        }
+        Expr::Map(entries) => {
+            for en in entries {
+                walk_expr(&en.key, f);
+                walk_expr(&en.value, f);
+            }
+        }
+        Expr::Call { args, .. } => {
+            for a in args {
+                walk_expr(&a.value, f);
+            }
+        }
+        Expr::StructLiteral { fields, .. } => {
+            for field in fields {
+                if let Some(v) = &field.value {
+                    walk_expr(v, f);
+                }
+            }
+        }
+        Expr::If {
+            cond,
+            then_branch,
+            else_branch,
+        } => {
+            walk_expr(cond, f);
+            walk_block(then_branch, f);
+            walk_block(else_branch, f);
+        }
+        Expr::For {
+            iter_expr, body, ..
+        } => {
+            walk_expr(iter_expr, f);
+            walk_block(body, f);
+        }
+        Expr::Field { receiver, .. } => walk_expr(receiver, f),
+        Expr::Match { scrutinee, arms } => {
+            walk_expr(scrutinee, f);
+            for arm in arms {
+                if let Some(g) = &arm.guard {
+                    walk_expr(g, f);
+                }
+                walk_expr(&arm.body, f);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use keron_lang::parse;
+
+    fn program(src: &str) -> Program {
+        parse(src).expect("test fixture parses")
+    }
+
+    /// Byte offset of the first occurrence of `needle` in `src`, plus
+    /// `add` to land inside the token.
+    fn at(src: &str, needle: &str, add: usize) -> usize {
+        src.find(needle).expect("needle present") + add
+    }
+
+    #[test]
+    fn finds_val_name_and_var_reference() {
+        let src = "val name: String = \"x\"\nval other: String = name\n";
+        let p = program(src);
+        match node_at(&p, at(src, "name", 1)) {
+            Some(NodeRef::ValName(v)) => assert_eq!(v.name.node, "name"),
+            other => panic!("expected ValName, got {other:?}"),
+        }
+        let ref_offset = src.rfind("name").unwrap() + 1;
+        match node_at(&p, ref_offset) {
+            Some(NodeRef::Var { name, .. }) => assert_eq!(name, "name"),
+            other => panic!("expected Var, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn finds_callee_inside_call() {
+        let src = "val s: Symlink = symlink(source = \"a\", target = \"b\")\n";
+        let p = program(src);
+        match node_at(&p, at(src, "symlink(", 3)) {
+            Some(NodeRef::Callee(c)) => assert_eq!(c.node, "symlink"),
+            other => panic!("expected Callee, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn finds_fn_name_param_and_var_in_body() {
+        let src = "fn greet(who: String): String { \"hi \" + who }\n";
+        let p = program(src);
+        match node_at(&p, at(src, "greet", 2)) {
+            Some(NodeRef::FnName(f)) => assert_eq!(f.name.node, "greet"),
+            other => panic!("expected FnName, got {other:?}"),
+        }
+        match node_at(&p, at(src, "who:", 1)) {
+            Some(NodeRef::ParamName(param)) => assert_eq!(param.name.node, "who"),
+            other => panic!("expected ParamName, got {other:?}"),
+        }
+        let body_ref = src.rfind("who").unwrap() + 1;
+        match node_at(&p, body_ref) {
+            Some(NodeRef::Var { name, .. }) => assert_eq!(name, "who"),
+            other => panic!("expected Var, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn finds_use_path_and_use_name() {
+        let src = "from \"./lib.keron\" use helper\n";
+        let p = program(src);
+        match node_at(&p, at(src, "./lib", 1)) {
+            Some(NodeRef::UsePath(u)) => assert_eq!(u.source.node, "./lib.keron"),
+            other => panic!("expected UsePath, got {other:?}"),
+        }
+        match node_at(&p, at(src, "helper", 2)) {
+            Some(NodeRef::UseName { name, .. }) => assert_eq!(name.node, "helper"),
+            other => panic!("expected UseName, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn finds_named_type_inside_list_annotation() {
+        let src = "struct Point { x: Int, y: Int }\nfn f(ps: List<Point>): Int { 1 }\n";
+        let p = program(src);
+        match node_at(&p, at(src, "List<Point>", 6)) {
+            Some(NodeRef::TypeName { name, .. }) => assert_eq!(name, "Point"),
+            other => panic!("expected TypeName, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn finds_field_access() {
+        let src = "struct P { x: Int }\nval p: P = P { x: 1 }\nval n: Int = p.x\n";
+        let p = program(src);
+        let offset = src.rfind(".x").unwrap() + 1;
+        match node_at(&p, offset) {
+            Some(NodeRef::FieldAccess { field, .. }) => assert_eq!(field.node, "x"),
+            other => panic!("expected FieldAccess, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn struct_literal_name_is_callee() {
+        let src = "struct P { x: Int }\nval p: P = P { x: 1 }\n";
+        let p = program(src);
+        let offset = src.find("P { x: 1").unwrap();
+        match node_at(&p, offset) {
+            Some(NodeRef::Callee(c)) => assert_eq!(c.node, "P"),
+            other => panic!("expected Callee, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn whitespace_between_items_finds_nothing() {
+        let src = "val a: Int = 1\n\nval b: Int = 2\n";
+        let p = program(src);
+        assert!(node_at(&p, src.find("\n\n").unwrap() + 1).is_none());
+    }
+
+    #[test]
+    fn enclosing_call_tracks_argument_index() {
+        let src = "fn two(a: Int, b: Int): Int { a + b }\nval n: Int = two(1, 2)\n";
+        let p = program(src);
+        let open = src.rfind('(').unwrap();
+        let ctx = enclosing_call(&p, open + 1).expect("inside call");
+        assert_eq!(ctx.callee.node, "two");
+        assert_eq!(ctx.active, 0);
+        assert_eq!(ctx.args.len(), 2);
+        let comma = src.rfind(',').unwrap();
+        let ctx = enclosing_call(&p, comma + 1).expect("after comma");
+        assert_eq!(ctx.active, 1);
+    }
+
+    #[test]
+    fn enclosing_call_prefers_the_inner_call() {
+        let src = "fn f(a: Int): Int { a }\nval n: Int = f(f(1))\n";
+        let p = program(src);
+        let inner = src.rfind("(1").unwrap();
+        let ctx = enclosing_call(&p, inner + 1).expect("inner call");
+        assert_eq!(ctx.callee.node, "f");
+        assert_eq!(ctx.active, 0);
+    }
+}

--- a/crates/keron-lsp/src/analysis/symbols.rs
+++ b/crates/keron-lsp/src/analysis/symbols.rs
@@ -1,0 +1,353 @@
+//! Name resolution helpers over a parsed module: find the local
+//! declaration a name refers to at a given offset, respecting keron's
+//! scoping rules (top-level fns/structs/aliases are order-independent;
+//! vals must precede their reference; params, `for` bindings, and
+//! match binds shadow outer names within their construct).
+
+use std::path::Path;
+
+use keron_lang::{
+    Block, Expr, FnDecl, ForPattern, Item, Param, Pattern, Program, Span, Spanned, Stmt,
+    StructDecl, TypeAliasDecl, ValDecl,
+};
+use keron_modules::{CheckedModule, ModuleId, Resolution};
+
+/// A local (same-module) definition site for a name.
+#[derive(Debug)]
+pub enum LocalDef<'a> {
+    Fn(&'a FnDecl),
+    Val(&'a ValDecl),
+    Struct(&'a StructDecl),
+    TypeAlias(&'a TypeAliasDecl),
+    Param(&'a Param),
+    /// A `for x in …` / `for (k, v) in …` binding or a match-pattern
+    /// bind. Only the name's span is available.
+    Binding {
+        name: String,
+        span: Span,
+    },
+}
+
+impl LocalDef<'_> {
+    /// Span of the defining name — the go-to-definition target.
+    #[must_use]
+    pub fn name_span(&self) -> Span {
+        match self {
+            Self::Fn(f) => f.name.span.clone(),
+            Self::Val(v) => v.name.span.clone(),
+            Self::Struct(s) => s.name.span.clone(),
+            Self::TypeAlias(t) => t.name.span.clone(),
+            Self::Param(p) => p.name.span.clone(),
+            Self::Binding { span, .. } => span.clone(),
+        }
+    }
+}
+
+const fn contains(span: &Span, offset: usize) -> bool {
+    span.start <= offset && offset < span.end
+}
+
+/// Find what `name`, referenced at `offset`, resolves to within this
+/// module. Inner scopes win over top-level declarations.
+#[must_use]
+pub fn find_local_def<'a>(program: &'a Program, name: &str, offset: usize) -> Option<LocalDef<'a>> {
+    for item in &program.items {
+        if contains(&item.span(), offset)
+            && let Some(def) = def_in_item(item, name, offset)
+        {
+            return Some(def);
+        }
+    }
+    top_level_def(program, name, offset)
+}
+
+/// Top-level declaration lookup. `offset` gates vals only: forward
+/// val references are check errors, so a val declared after the
+/// cursor is not a candidate.
+fn top_level_def<'a>(program: &'a Program, name: &str, offset: usize) -> Option<LocalDef<'a>> {
+    program.items.iter().find_map(|item| match item {
+        Item::Fn(f) if f.name.node == name => Some(LocalDef::Fn(f)),
+        Item::Struct(s) if s.name.node == name => Some(LocalDef::Struct(s)),
+        Item::TypeAlias(t) if t.name.node == name => Some(LocalDef::TypeAlias(t)),
+        Item::Val(v) if v.name.node == name && v.span.start <= offset => Some(LocalDef::Val(v)),
+        _ => None,
+    })
+}
+
+fn def_in_item<'a>(item: &'a Item, name: &str, offset: usize) -> Option<LocalDef<'a>> {
+    match item {
+        Item::Fn(f) => def_in_block(&f.body, name, offset).or_else(|| {
+            f.params
+                .iter()
+                .find(|p| p.name.node == name)
+                .map(LocalDef::Param)
+        }),
+        Item::Val(v) => def_in_expr(&v.value, name, offset),
+        Item::ExprStmt(e) => def_in_expr(e, name, offset),
+        Item::Reconcile(r) => r
+            .chains
+            .iter()
+            .flatten()
+            .find_map(|e| def_in_expr(e, name, offset)),
+        Item::Struct(s) => s
+            .fields
+            .iter()
+            .filter_map(|f| f.default.as_ref())
+            .find_map(|d| def_in_expr(d, name, offset)),
+        Item::Use(_) | Item::TypeAlias(_) => None,
+    }
+}
+
+fn def_in_block<'a>(b: &'a Block, name: &str, offset: usize) -> Option<LocalDef<'a>> {
+    if !contains(&b.span, offset) {
+        return None;
+    }
+    // Inner constructs first (their bindings shadow this block's vals).
+    for stmt in &b.stmts {
+        let found = match stmt {
+            Stmt::Val(v) => def_in_expr(&v.value, name, offset),
+            Stmt::Reconcile(r) => r
+                .chains
+                .iter()
+                .flatten()
+                .find_map(|e| def_in_expr(e, name, offset)),
+            Stmt::Expr(e) => def_in_expr(e, name, offset),
+        };
+        if found.is_some() {
+            return found;
+        }
+    }
+    if let Some(t) = &b.trailing
+        && let Some(found) = def_in_expr(t, name, offset)
+    {
+        return Some(found);
+    }
+    // Then this block's own vals, declaration-before-use.
+    for stmt in &b.stmts {
+        if let Stmt::Val(v) = stmt
+            && v.name.node == name
+            && v.span.start <= offset
+        {
+            return Some(LocalDef::Val(v));
+        }
+    }
+    None
+}
+
+fn def_in_expr<'a>(e: &'a Spanned<Expr>, name: &str, offset: usize) -> Option<LocalDef<'a>> {
+    if !contains(&e.span, offset) {
+        return None;
+    }
+    match &e.node {
+        Expr::Unary { operand, .. } => def_in_expr(operand, name, offset),
+        Expr::Binary { lhs, rhs, .. } => {
+            def_in_expr(lhs, name, offset).or_else(|| def_in_expr(rhs, name, offset))
+        }
+        Expr::Interpolation(parts) => parts.iter().find_map(|p| match p {
+            keron_lang::StringPart::Expr { expr, .. } => def_in_expr(expr, name, offset),
+            keron_lang::StringPart::Text(_) => None,
+        }),
+        Expr::List(items) => items.iter().find_map(|x| def_in_expr(x, name, offset)),
+        Expr::Map(entries) => entries.iter().find_map(|en| {
+            def_in_expr(&en.key, name, offset).or_else(|| def_in_expr(&en.value, name, offset))
+        }),
+        Expr::Call { args, .. } => args
+            .iter()
+            .find_map(|a| def_in_expr(&a.value, name, offset)),
+        Expr::StructLiteral { fields, .. } => fields
+            .iter()
+            .filter_map(|f| f.value.as_ref())
+            .find_map(|v| def_in_expr(v, name, offset)),
+        Expr::If {
+            cond,
+            then_branch,
+            else_branch,
+        } => def_in_expr(cond, name, offset)
+            .or_else(|| def_in_block(then_branch, name, offset))
+            .or_else(|| def_in_block(else_branch, name, offset)),
+        Expr::For {
+            pattern,
+            iter_expr,
+            body,
+        } => {
+            if let Some(found) = def_in_expr(iter_expr, name, offset) {
+                return Some(found);
+            }
+            if !contains(&body.span, offset) {
+                return None;
+            }
+            def_in_block(body, name, offset).or_else(|| for_binding(pattern, name))
+        }
+        Expr::Field { receiver, .. } => def_in_expr(receiver, name, offset),
+        Expr::Match { scrutinee, arms } => {
+            def_in_expr(scrutinee, name, offset).or_else(|| {
+                arms.iter().find_map(|arm| {
+                    let in_arm_body = arm
+                        .guard
+                        .as_ref()
+                        .and_then(|g| def_in_expr(g, name, offset))
+                        .or_else(|| def_in_expr(&arm.body, name, offset));
+                    // Pattern binds are only in scope for this arm.
+                    if in_arm_body.is_some() {
+                        return in_arm_body;
+                    }
+                    let arm_scope = contains(&arm.span, offset) && offset >= arm.pattern.span.start;
+                    arm_scope
+                        .then(|| pattern_binding(&arm.pattern, name))
+                        .flatten()
+                })
+            })
+        }
+        Expr::Literal(_) | Expr::Var(_) => None,
+    }
+}
+
+fn for_binding<'a>(pattern: &ForPattern, name: &str) -> Option<LocalDef<'a>> {
+    let found = match pattern {
+        ForPattern::Elem(n) => (n.node == name).then_some(n),
+        ForPattern::Entry { key, value } => (key.node == name)
+            .then_some(key)
+            .or_else(|| (value.node == name).then_some(value)),
+    }?;
+    Some(LocalDef::Binding {
+        name: found.node.clone(),
+        span: found.span.clone(),
+    })
+}
+
+fn pattern_binding<'a>(p: &Spanned<Pattern>, name: &str) -> Option<LocalDef<'a>> {
+    match &p.node {
+        Pattern::Bind(n) if n == name => Some(LocalDef::Binding {
+            name: n.clone(),
+            span: p.span.clone(),
+        }),
+        Pattern::Struct { fields, .. } => fields.iter().find_map(|f| {
+            f.pattern.as_ref().map_or_else(
+                // Shorthand `Name { field }` binds the field's value
+                // to its own name.
+                || {
+                    (f.name.node == name).then(|| LocalDef::Binding {
+                        name: f.name.node.clone(),
+                        span: f.name.span.clone(),
+                    })
+                },
+                |sub| pattern_binding(sub, name),
+            )
+        }),
+        Pattern::Bind(_) | Pattern::Lit(_) | Pattern::Wildcard => None,
+    }
+}
+
+/// The checked module backing `path` in the latest resolution, if it
+/// resolved at all.
+#[must_use]
+pub fn module_for<'r>(resolution: &'r Resolution, path: &Path) -> Option<&'r CheckedModule> {
+    resolution.graph.modules.get(&ModuleId(path.to_path_buf()))
+}
+
+/// The span of top-level declaration `name` in `program` — where an
+/// import of that name should jump to.
+#[must_use]
+pub fn top_level_decl_span(program: &Program, name: &str) -> Option<Span> {
+    program.items.iter().find_map(|item| match item {
+        Item::Fn(f) if f.name.node == name => Some(f.name.span.clone()),
+        Item::Val(v) if v.name.node == name => Some(v.name.span.clone()),
+        Item::Struct(s) if s.name.node == name => Some(s.name.span.clone()),
+        Item::TypeAlias(t) if t.name.node == name => Some(t.name.span.clone()),
+        _ => None,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use keron_lang::parse;
+
+    fn program(src: &str) -> Program {
+        parse(src).expect("fixture parses")
+    }
+
+    #[test]
+    fn param_shadows_top_level_val() {
+        let src = "val x: Int = 1\nfn f(x: Int): Int { x }\n";
+        let p = program(src);
+        let body_ref = src.rfind('x').unwrap();
+        match find_local_def(&p, "x", body_ref) {
+            Some(LocalDef::Param(param)) => assert_eq!(param.name.node, "x"),
+            other => panic!("expected Param, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn top_level_val_must_precede_reference() {
+        let src = "val a: Int = b\nval b: Int = 2\n";
+        let p = program(src);
+        let a_ref = src.find("= b").unwrap() + 2;
+        assert!(
+            find_local_def(&p, "b", a_ref).is_none(),
+            "forward val reference must not resolve"
+        );
+        let src2 = "val b: Int = 2\nval a: Int = b\n";
+        let p2 = program(src2);
+        let b_ref = src2.rfind('b').unwrap();
+        match find_local_def(&p2, "b", b_ref) {
+            Some(LocalDef::Val(v)) => assert_eq!(v.name.node, "b"),
+            other => panic!("expected Val, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn fn_is_found_regardless_of_order() {
+        let src = "val n: Int = later()\nfn later(): Int { 1 }\n";
+        let p = program(src);
+        match find_local_def(&p, "later", src.find("later()").unwrap()) {
+            Some(LocalDef::Fn(f)) => assert_eq!(f.name.node, "later"),
+            other => panic!("expected Fn, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn for_binding_resolves_inside_body_only() {
+        let src = "fn f(xs: List<Int>): Void { for x in xs { reconcile_nothing(x) } }\n";
+        // `reconcile_nothing` isn't real; parse only cares about shape.
+        let p = program(src);
+        let body_ref = src.rfind("(x)").unwrap() + 1;
+        match find_local_def(&p, "x", body_ref) {
+            Some(LocalDef::Binding { name, .. }) => assert_eq!(name, "x"),
+            other => panic!("expected Binding, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn block_local_val_shadows_param() {
+        let src = "fn f(x: Int): Int { val y = x + 1\n y }\n";
+        let p = program(src);
+        let y_ref = src.rfind('y').unwrap();
+        match find_local_def(&p, "y", y_ref) {
+            Some(LocalDef::Val(v)) => assert_eq!(v.name.node, "y"),
+            other => panic!("expected block-local Val, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn match_bind_resolves_in_arm_body() {
+        let src = "fn f(s: String): String { match s { v => v } }\n";
+        let p = program(src);
+        let v_ref = src.rfind('v').unwrap();
+        match find_local_def(&p, "v", v_ref) {
+            Some(LocalDef::Binding { name, .. }) => assert_eq!(name, "v"),
+            other => panic!("expected match Binding, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn top_level_decl_span_finds_each_kind() {
+        let src = "fn f(): Int { 1 }\nval v: Int = 1\nstruct S { x: Int }\ntype T = \"a\"\n";
+        let p = program(src);
+        for name in ["f", "v", "S", "T"] {
+            let span = top_level_decl_span(&p, name).expect(name);
+            assert_eq!(&src[span], name);
+        }
+        assert!(top_level_decl_span(&p, "missing").is_none());
+    }
+}

--- a/crates/keron-lsp/src/handlers/completion.rs
+++ b/crates/keron-lsp/src/handlers/completion.rs
@@ -1,0 +1,161 @@
+//! `textDocument/completion` — a flat identifier list: keywords,
+//! stdlib builtins, module-local declarations, and imports. One
+//! context refinement: inside a `from "…" use …` names list only the
+//! target module's exports are offered.
+
+use std::fs;
+
+use keron_lang::{Item, Type};
+use lsp_types::{CompletionItem, CompletionItemKind, CompletionParams, CompletionResponse};
+
+use crate::handlers::{Snapshot, render, snapshot_at};
+use crate::state::ServerState;
+
+const KEYWORDS: &[&str] = &[
+    "val",
+    "fn",
+    "struct",
+    "type",
+    "reconcile",
+    "from",
+    "use",
+    "if",
+    "else",
+    "for",
+    "in",
+    "match",
+    "true",
+    "false",
+    "null",
+];
+
+pub fn handle(state: &ServerState, params: &CompletionParams) -> Option<CompletionResponse> {
+    let pos = &params.text_document_position;
+    let snap = snapshot_at(state, &pos.text_document.uri)?;
+    let offset = snap.index.offset(snap.text, pos.position)?;
+    if let Some(items) = use_names_completion(&snap, offset) {
+        return Some(CompletionResponse::Array(items));
+    }
+    Some(CompletionResponse::Array(scope_completion(&snap)))
+}
+
+/// When the cursor sits in the names list of a `use` item, offer only
+/// what the target module actually exports.
+fn use_names_completion(snap: &Snapshot<'_>, offset: usize) -> Option<Vec<CompletionItem>> {
+    let use_decl = snap.program.items.iter().find_map(|item| match item {
+        Item::Use(u)
+            if u.span.start <= offset && offset <= u.span.end && offset > u.source.span.end =>
+        {
+            Some(u)
+        }
+        _ => None,
+    })?;
+    let resolution = snap.resolution?;
+    let base = snap.path.parent()?;
+    let target = fs::canonicalize(base.join(&use_decl.source.node)).ok()?;
+    let module = resolution
+        .graph
+        .modules
+        .get(&keron_modules::ModuleId(target))?;
+    let mut items = Vec::new();
+    for name in &module.exported_fns {
+        items.push(item(name, CompletionItemKind::FUNCTION, None));
+    }
+    for name in &module.exported_vals {
+        items.push(item(name, CompletionItemKind::VARIABLE, None));
+    }
+    for (name, ty) in &module.exported_types {
+        items.push(item(name, type_kind(ty), None));
+    }
+    dedup(&mut items);
+    Some(items)
+}
+
+fn scope_completion(snap: &Snapshot<'_>) -> Vec<CompletionItem> {
+    let mut items: Vec<CompletionItem> = KEYWORDS
+        .iter()
+        .map(|kw| item(kw, CompletionItemKind::KEYWORD, None))
+        .collect();
+
+    // Everything imported into scope: stdlib builtins plus resolved
+    // `use` items, with real signatures as detail text.
+    let imported = snap.imported_symbols();
+    for (name, sig) in &imported.fns {
+        items.push(item(
+            name,
+            if sig.struct_name.is_some() {
+                CompletionItemKind::STRUCT
+            } else {
+                CompletionItemKind::FUNCTION
+            },
+            Some(render::fn_sig_signature(name, sig)),
+        ));
+    }
+    for (name, ty) in &imported.types {
+        items.push(item(name, type_kind(ty), Some(ty.to_string())));
+    }
+    for (name, ty) in &imported.vals {
+        items.push(item(
+            name,
+            CompletionItemKind::VARIABLE,
+            Some(format!("val {name}: {ty}")),
+        ));
+    }
+
+    // Module-local declarations.
+    for decl in &snap.program.items {
+        match decl {
+            Item::Fn(f) => items.push(item(
+                &f.name.node,
+                CompletionItemKind::FUNCTION,
+                Some(render::fn_decl_signature(f)),
+            )),
+            Item::Val(v) => items.push(item(
+                &v.name.node,
+                CompletionItemKind::VARIABLE,
+                Some(render::val_decl_signature(v)),
+            )),
+            Item::Struct(s) => items.push(item(
+                &s.name.node,
+                CompletionItemKind::STRUCT,
+                Some(render::struct_decl_signature(s)),
+            )),
+            Item::TypeAlias(t) => items.push(item(
+                &t.name.node,
+                CompletionItemKind::ENUM,
+                Some(render::type_alias_signature(t)),
+            )),
+            _ => {}
+        }
+    }
+
+    dedup(&mut items);
+    items
+}
+
+const fn type_kind(ty: &Type) -> CompletionItemKind {
+    match ty {
+        Type::StringUnion { .. } => CompletionItemKind::ENUM,
+        Type::Struct { .. } => CompletionItemKind::STRUCT,
+        _ => CompletionItemKind::CLASS,
+    }
+}
+
+fn item(label: &str, kind: CompletionItemKind, detail: Option<String>) -> CompletionItem {
+    CompletionItem {
+        label: label.to_string(),
+        kind: Some(kind),
+        detail,
+        ..Default::default()
+    }
+}
+
+/// Local declarations also appear via `imported_symbols` only when
+/// imported elsewhere, but a name can still show up twice (e.g. local
+/// decl + stale import). Keep the first occurrence, which is the one
+/// with the most specific detail.
+fn dedup(items: &mut Vec<CompletionItem>) {
+    let mut seen = std::collections::HashSet::new();
+    items.retain(|i| seen.insert(i.label.clone()));
+    items.sort_by(|a, b| a.label.cmp(&b.label));
+}

--- a/crates/keron-lsp/src/handlers/definition.rs
+++ b/crates/keron-lsp/src/handlers/definition.rs
@@ -1,0 +1,71 @@
+//! `textDocument/definition` — local declarations, cross-file imports,
+//! and `use`-path targets.
+
+use std::fs;
+
+use keron_modules::CheckedModule;
+use lsp_types::{GotoDefinitionParams, GotoDefinitionResponse, Location, Position, Range};
+
+use crate::analysis::node_at::{NodeRef, node_at};
+use crate::analysis::symbols::{find_local_def, top_level_decl_span};
+use crate::handlers::{Snapshot, snapshot_at};
+use crate::line_index::LineIndex;
+use crate::state::ServerState;
+use crate::uri::path_to_uri;
+
+pub fn handle(
+    state: &ServerState,
+    params: &GotoDefinitionParams,
+) -> Option<GotoDefinitionResponse> {
+    let pos = &params.text_document_position_params;
+    let snap = snapshot_at(state, &pos.text_document.uri)?;
+    let offset = snap.index.offset(snap.text, pos.position)?;
+    let location = match node_at(snap.program, offset)? {
+        NodeRef::Callee(name) => named_def(&snap, &name.node, offset),
+        NodeRef::Var { name, .. } | NodeRef::TypeName { name, .. } => {
+            named_def(&snap, name, offset)
+        }
+        NodeRef::UseName { name, .. } => imported_def(&snap, &name.node),
+        NodeRef::UsePath(u) => use_path_target(&snap, &u.source.node),
+        // Already at the definition.
+        _ => None,
+    }?;
+    Some(GotoDefinitionResponse::Scalar(location))
+}
+
+fn named_def(snap: &Snapshot<'_>, name: &str, offset: usize) -> Option<Location> {
+    if let Some(def) = find_local_def(snap.program, name, offset) {
+        return Some(Location {
+            uri: snap.doc.uri.clone(),
+            range: snap.index.range(snap.text, &def.name_span()),
+        });
+    }
+    imported_def(snap, name)
+}
+
+/// Follow `name` through this module's resolved imports to the
+/// declaration in its origin module. Builtins have no source to jump
+/// to and return `None`.
+fn imported_def(snap: &Snapshot<'_>, name: &str) -> Option<Location> {
+    let resolution = snap.resolution?;
+    let module = snap.module()?;
+    let (origin_id, original_name) = module.imports.get(name)?;
+    let origin: &CheckedModule = resolution.graph.modules.get(origin_id)?;
+    let span = top_level_decl_span(&origin.program, original_name)?;
+    let index = LineIndex::new(&origin.source);
+    Some(Location {
+        uri: path_to_uri(&origin_id.0)?,
+        range: index.range(&origin.source, &span),
+    })
+}
+
+/// `from "./x.keron" …` with the cursor on the path: jump to the top
+/// of the target file.
+fn use_path_target(snap: &Snapshot<'_>, raw_path: &str) -> Option<Location> {
+    let base = snap.path.parent()?;
+    let target = fs::canonicalize(base.join(raw_path)).ok()?;
+    Some(Location {
+        uri: path_to_uri(&target)?,
+        range: Range::new(Position::new(0, 0), Position::new(0, 0)),
+    })
+}

--- a/crates/keron-lsp/src/handlers/diagnostics.rs
+++ b/crates/keron-lsp/src/handlers/diagnostics.rs
@@ -1,0 +1,68 @@
+//! `keron_lang::Diagnostic` → `lsp_types::Diagnostic` conversion.
+
+use lsp_types::DiagnosticSeverity;
+
+use crate::line_index::LineIndex;
+
+/// Convert one keron diagnostic against the source text its span
+/// refers to. keron diagnostics carry no severity — everything the
+/// frontend emits is an error. `note:` / `help:` have no spans of
+/// their own, so they are appended to the message the way rustc-style
+/// servers render span-less children.
+pub fn to_lsp(
+    diag: &keron_lang::Diagnostic,
+    text: &str,
+    index: &LineIndex,
+) -> lsp_types::Diagnostic {
+    let mut message = diag.message.clone();
+    if let Some(note) = &diag.note {
+        message.push_str("\nnote: ");
+        message.push_str(note);
+    }
+    if let Some(help) = &diag.help {
+        message.push_str("\nhelp: ");
+        message.push_str(help);
+    }
+    lsp_types::Diagnostic {
+        range: index.range(text, &diag.span),
+        severity: Some(DiagnosticSeverity::ERROR),
+        source: Some("keron".to_string()),
+        message,
+        ..Default::default()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use keron_lang::Diagnostic;
+    use lsp_types::Position;
+
+    #[test]
+    fn maps_span_and_appends_note_and_help() {
+        let text = "val x: Int = \"hi\"\n";
+        let index = LineIndex::new(text);
+        let diag = Diagnostic::new(13..17, "expected `Int`, found `String`")
+            .with_note("the annotation says `Int`")
+            .with_help("change the annotation to `String`");
+        let lsp = to_lsp(&diag, text, &index);
+        assert_eq!(lsp.range.start, Position::new(0, 13));
+        assert_eq!(lsp.range.end, Position::new(0, 17));
+        assert_eq!(lsp.severity, Some(DiagnosticSeverity::ERROR));
+        assert_eq!(lsp.source.as_deref(), Some("keron"));
+        assert_eq!(
+            lsp.message,
+            "expected `Int`, found `String`\nnote: the annotation says `Int`\nhelp: change the annotation to `String`"
+        );
+    }
+
+    #[test]
+    fn out_of_range_span_clamps_instead_of_panicking() {
+        let text = "x";
+        let index = LineIndex::new(text);
+        let diag = Diagnostic::new(50..60, "boom");
+        let lsp = to_lsp(&diag, text, &index);
+        assert_eq!(lsp.range.start, Position::new(0, 1));
+        assert_eq!(lsp.range.end, Position::new(0, 1));
+    }
+}

--- a/crates/keron-lsp/src/handlers/document_symbol.rs
+++ b/crates/keron-lsp/src/handlers/document_symbol.rs
@@ -1,0 +1,112 @@
+//! `textDocument/documentSymbol` — the outline view: top-level
+//! declarations, with struct fields as children.
+
+use keron_lang::Item;
+use lsp_types::{DocumentSymbol, DocumentSymbolParams, DocumentSymbolResponse, SymbolKind};
+
+use crate::handlers::{render, snapshot_at};
+use crate::state::ServerState;
+
+pub fn handle(
+    state: &ServerState,
+    params: &DocumentSymbolParams,
+) -> Option<DocumentSymbolResponse> {
+    let snap = snapshot_at(state, &params.text_document.uri)?;
+    let symbols: Vec<DocumentSymbol> = snap
+        .program
+        .items
+        .iter()
+        .filter_map(|item| item_symbol(item, snap.text, snap.index))
+        .collect();
+    Some(DocumentSymbolResponse::Nested(symbols))
+}
+
+// lsp-types deprecates `DocumentSymbol::deprecated` in favor of
+// `tags`, but struct construction still requires the field.
+#[allow(deprecated)]
+const fn symbol(
+    name: String,
+    detail: Option<String>,
+    kind: SymbolKind,
+    range: lsp_types::Range,
+    selection_range: lsp_types::Range,
+    children: Option<Vec<DocumentSymbol>>,
+) -> DocumentSymbol {
+    DocumentSymbol {
+        name,
+        detail,
+        kind,
+        tags: None,
+        deprecated: None,
+        range,
+        selection_range,
+        children,
+    }
+}
+
+fn item_symbol(
+    item: &Item,
+    text: &str,
+    index: &crate::line_index::LineIndex,
+) -> Option<DocumentSymbol> {
+    let range = index.range(text, &item.span());
+    match item {
+        Item::Fn(f) => Some(symbol(
+            f.name.node.clone(),
+            Some(render::fn_decl_signature(f)),
+            SymbolKind::FUNCTION,
+            range,
+            index.range(text, &f.name.span),
+            None,
+        )),
+        Item::Val(v) => Some(symbol(
+            v.name.node.clone(),
+            Some(render::val_decl_signature(v)),
+            SymbolKind::CONSTANT,
+            range,
+            index.range(text, &v.name.span),
+            None,
+        )),
+        Item::Struct(s) => {
+            let children: Vec<DocumentSymbol> = s
+                .fields
+                .iter()
+                .map(|f| {
+                    symbol(
+                        f.name.node.clone(),
+                        Some(f.ty.node.to_string()),
+                        SymbolKind::FIELD,
+                        index.range(text, &f.span),
+                        index.range(text, &f.name.span),
+                        None,
+                    )
+                })
+                .collect();
+            Some(symbol(
+                s.name.node.clone(),
+                Some(render::struct_decl_signature(s)),
+                SymbolKind::STRUCT,
+                range,
+                index.range(text, &s.name.span),
+                Some(children),
+            ))
+        }
+        Item::TypeAlias(t) => Some(symbol(
+            t.name.node.clone(),
+            Some(render::type_alias_signature(t)),
+            SymbolKind::ENUM,
+            range,
+            index.range(text, &t.name.span),
+            None,
+        )),
+        Item::Reconcile(r) => Some(symbol(
+            "reconcile".to_string(),
+            None,
+            SymbolKind::EVENT,
+            range,
+            index.range(text, &r.span),
+            None,
+        )),
+        Item::Use(_) | Item::ExprStmt(_) => None,
+    }
+}

--- a/crates/keron-lsp/src/handlers/formatting.rs
+++ b/crates/keron-lsp/src/handlers/formatting.rs
@@ -1,0 +1,23 @@
+//! `textDocument/formatting` — reuse the `keron format` engine as one
+//! whole-document text edit.
+
+use lsp_types::{DocumentFormattingParams, Position, Range, TextEdit};
+
+use crate::state::ServerState;
+
+/// Format the *current* buffer text (not the last-good snapshot — the
+/// user asked to format what they see). Unparseable buffers return
+/// `None`: diagnostics already explain the problem, and erroring the
+/// request would just make editors pop noise.
+pub fn handle(state: &ServerState, params: &DocumentFormattingParams) -> Option<Vec<TextEdit>> {
+    let (_, doc) = state.doc_by_uri(&params.text_document.uri)?;
+    let formatted = keron_lang::format(&doc.text).ok()?;
+    if formatted == doc.text {
+        return Some(Vec::new());
+    }
+    let end = doc.line_index.end_position(&doc.text);
+    Some(vec![TextEdit {
+        range: Range::new(Position::new(0, 0), end),
+        new_text: formatted,
+    }])
+}

--- a/crates/keron-lsp/src/handlers/hover.rs
+++ b/crates/keron-lsp/src/handlers/hover.rs
@@ -1,0 +1,170 @@
+//! `textDocument/hover` — signatures and types for the node under the
+//! cursor, rendered as a fenced keron code block.
+
+use keron_lang::{ImportedSymbols, Program, Span, Type};
+use lsp_types::{Hover, HoverContents, HoverParams, MarkupContent, MarkupKind};
+
+use crate::analysis::node_at::{NodeRef, node_at};
+use crate::analysis::symbols::{LocalDef, find_local_def};
+use crate::handlers::render;
+use crate::handlers::snapshot_at;
+use crate::state::ServerState;
+
+pub fn handle(state: &ServerState, params: &HoverParams) -> Option<Hover> {
+    let pos = &params.text_document_position_params;
+    let snap = snapshot_at(state, &pos.text_document.uri)?;
+    let offset = snap.index.offset(snap.text, pos.position)?;
+    let node = node_at(snap.program, offset)?;
+    let imported = snap.imported_symbols();
+    let (text, span) = describe(&node, snap.program, offset, &imported)?;
+    Some(Hover {
+        contents: HoverContents::Markup(MarkupContent {
+            kind: MarkupKind::Markdown,
+            value: format!("```keron\n{text}\n```"),
+        }),
+        range: span.map(|s| snap.index.range(snap.text, &s)),
+    })
+}
+
+fn describe(
+    node: &NodeRef<'_>,
+    program: &Program,
+    offset: usize,
+    imported: &ImportedSymbols,
+) -> Option<(String, Option<Span>)> {
+    match node {
+        NodeRef::Callee(name) => Some((
+            callable_text(program, &name.node, offset, imported)?,
+            Some(name.span.clone()),
+        )),
+        NodeRef::Var { name, span } => Some((
+            var_text(program, name, offset, imported)?,
+            Some(span.clone()),
+        )),
+        NodeRef::FieldAccess { receiver, field } => Some((
+            field_access_text(program, receiver, &field.node, imported)?,
+            Some(field.span.clone()),
+        )),
+        NodeRef::TypeName { name, span } => {
+            Some((type_text(program, name, imported)?, Some(span.clone())))
+        }
+        NodeRef::FnName(f) => Some((render::fn_decl_signature(f), Some(f.name.span.clone()))),
+        NodeRef::ValName(v) => Some((render::val_decl_signature(v), Some(v.name.span.clone()))),
+        NodeRef::StructName(s) => {
+            Some((render::struct_decl_signature(s), Some(s.name.span.clone())))
+        }
+        NodeRef::TypeAliasName(t) => {
+            Some((render::type_alias_signature(t), Some(t.name.span.clone())))
+        }
+        NodeRef::ParamName(p) => Some((
+            format!("{}: {}", p.name.node, p.ty.node),
+            Some(p.name.span.clone()),
+        )),
+        NodeRef::StructFieldName(f) => Some((
+            format!("{}: {}", f.name.node, f.ty.node),
+            Some(f.name.span.clone()),
+        )),
+        NodeRef::UseName { name, .. } => Some((
+            callable_text(program, &name.node, offset, imported)
+                .or_else(|| var_text(program, &name.node, offset, imported))
+                .or_else(|| type_text(program, &name.node, imported))?,
+            Some(name.span.clone()),
+        )),
+        NodeRef::UsePath(_) => None,
+    }
+}
+
+/// Hover text for something invoked: a local fn/struct, an imported
+/// fn, or a builtin.
+fn callable_text(
+    program: &Program,
+    name: &str,
+    offset: usize,
+    imported: &ImportedSymbols,
+) -> Option<String> {
+    match find_local_def(program, name, offset) {
+        Some(LocalDef::Fn(f)) => return Some(render::fn_decl_signature(f)),
+        Some(LocalDef::Struct(s)) => return Some(render::struct_decl_signature(s)),
+        Some(LocalDef::TypeAlias(t)) => return Some(render::type_alias_signature(t)),
+        _ => {}
+    }
+    imported
+        .fns
+        .get(name)
+        .map(|sig| render::fn_sig_signature(name, sig))
+}
+
+fn var_text(
+    program: &Program,
+    name: &str,
+    offset: usize,
+    imported: &ImportedSymbols,
+) -> Option<String> {
+    match find_local_def(program, name, offset) {
+        Some(LocalDef::Val(v)) => return Some(render::val_decl_signature(v)),
+        Some(LocalDef::Param(p)) => return Some(format!("{}: {}", p.name.node, p.ty.node)),
+        Some(LocalDef::Binding { name, .. }) => return Some(name),
+        Some(LocalDef::Fn(f)) => return Some(render::fn_decl_signature(f)),
+        Some(LocalDef::Struct(s)) => return Some(render::struct_decl_signature(s)),
+        _ => {}
+    }
+    imported
+        .vals
+        .get(name)
+        .map(|ty| format!("val {name}: {ty}"))
+}
+
+fn type_text(program: &Program, name: &str, imported: &ImportedSymbols) -> Option<String> {
+    for item in &program.items {
+        match item {
+            keron_lang::Item::Struct(s) if s.name.node == name => {
+                return Some(render::struct_decl_signature(s));
+            }
+            keron_lang::Item::TypeAlias(t) if t.name.node == name => {
+                return Some(render::type_alias_signature(t));
+            }
+            _ => {}
+        }
+    }
+    imported.types.get(name).map(|ty| render_type(name, ty))
+}
+
+fn render_type(name: &str, ty: &Type) -> String {
+    match ty {
+        Type::Struct { name, fields } => {
+            let fields: Vec<String> = fields.iter().map(|(f, t)| format!("{f}: {t}")).collect();
+            format!("struct {name} {{ {} }}", fields.join(", "))
+        }
+        Type::StringUnion { name, variants } => {
+            let variants: Vec<String> = variants.iter().map(|v| format!("\"{v}\"")).collect();
+            format!("type {name} = {}", variants.join(" | "))
+        }
+        _ => name.to_string(),
+    }
+}
+
+/// `receiver.field` hover: only resolvable without inference when the
+/// receiver is a plain var whose annotated type is a known struct.
+fn field_access_text(
+    program: &Program,
+    receiver: &keron_lang::Spanned<keron_lang::Expr>,
+    field: &str,
+    imported: &ImportedSymbols,
+) -> Option<String> {
+    let keron_lang::Expr::Var(var_name) = &receiver.node else {
+        return None;
+    };
+    let receiver_ty = match find_local_def(program, var_name, receiver.span.start) {
+        Some(LocalDef::Val(v)) => v.ty.as_ref().map(|t| t.node.clone()),
+        Some(LocalDef::Param(p)) => Some(p.ty.node.clone()),
+        _ => None,
+    }
+    .or_else(|| imported.vals.get(var_name).cloned())?;
+    let Type::Struct { fields, .. } = receiver_ty else {
+        return None;
+    };
+    fields
+        .iter()
+        .find(|(f, _)| f == field)
+        .map(|(f, t)| format!("{f}: {t}"))
+}

--- a/crates/keron-lsp/src/handlers/mod.rs
+++ b/crates/keron-lsp/src/handlers/mod.rs
@@ -1,0 +1,224 @@
+//! Request/notification dispatch. Every handler is a pure function
+//! over [`ServerState`]; the main loop owns all channel IO.
+
+pub mod completion;
+pub mod definition;
+pub mod diagnostics;
+pub mod document_symbol;
+pub mod formatting;
+pub mod hover;
+pub mod render;
+pub mod semantic_tokens;
+pub mod signature_help;
+
+use std::fs;
+use std::path::PathBuf;
+
+use keron_lang::{ImportedSymbols, Program};
+use keron_modules::{CheckedModule, Resolution};
+use lsp_server::{ErrorCode, Notification, Request, RequestId, Response};
+use lsp_types::notification::{
+    DidChangeTextDocument, DidCloseTextDocument, DidOpenTextDocument, Notification as _,
+    PublishDiagnostics,
+};
+use lsp_types::request::{
+    Completion, DocumentSymbolRequest, Formatting, GotoDefinition, HoverRequest, Request as _,
+    SemanticTokensFullRequest, SignatureHelpRequest,
+};
+use lsp_types::{
+    DidChangeTextDocumentParams, DidCloseTextDocumentParams, DidOpenTextDocumentParams,
+    PublishDiagnosticsParams, Uri,
+};
+
+use crate::analysis::analyze;
+use crate::analysis::symbols::module_for;
+use crate::line_index::LineIndex;
+use crate::state::{Document, LastGood, ServerState};
+use crate::uri::uri_to_path;
+
+/// The read view feature handlers work against: the last-good parse of
+/// one document plus the workspace resolution. Spans in `program` are
+/// valid against `text`/`index` (which may lag the live buffer while
+/// an edit is unparseable).
+pub struct Snapshot<'s> {
+    pub program: &'s Program,
+    pub text: &'s str,
+    pub index: &'s LineIndex,
+    pub doc: &'s Document,
+    pub path: &'s PathBuf,
+    pub resolution: Option<&'s Resolution>,
+}
+
+impl Snapshot<'_> {
+    /// This document's module in the latest resolution, if it checked.
+    #[must_use]
+    pub fn module(&self) -> Option<&CheckedModule> {
+        self.resolution.and_then(|r| module_for(r, self.path))
+    }
+
+    /// Everything in scope: stdlib builtins plus resolved imports
+    /// (stdlib only when the module didn't resolve).
+    #[must_use]
+    pub fn imported_symbols(&self) -> ImportedSymbols {
+        self.resolution
+            .and_then(|r| {
+                module_for(r, self.path).map(|m| keron_modules::imported_symbols(m, &r.graph))
+            })
+            .unwrap_or_else(keron_modules::stdlib_symbols)
+    }
+}
+
+/// Build the feature-request view for `uri`. `None` when the document
+/// isn't open or has never parsed.
+#[must_use]
+pub fn snapshot_at<'s>(state: &'s ServerState, uri: &Uri) -> Option<Snapshot<'s>> {
+    let (path, doc) = state.doc_by_uri(uri)?;
+    let last_good = doc.last_good.as_ref()?;
+    Some(Snapshot {
+        program: &last_good.program,
+        text: &last_good.text,
+        index: &last_good.line_index,
+        doc,
+        path,
+        resolution: state.resolution.as_ref(),
+    })
+}
+
+pub fn handle_request(state: &ServerState, req: Request) -> Response {
+    match req.method.as_str() {
+        HoverRequest::METHOD => respond(req.id, req.params, |p| hover::handle(state, &p)),
+        GotoDefinition::METHOD => respond(req.id, req.params, |p| definition::handle(state, &p)),
+        Completion::METHOD => respond(req.id, req.params, |p| completion::handle(state, &p)),
+        DocumentSymbolRequest::METHOD => {
+            respond(req.id, req.params, |p| document_symbol::handle(state, &p))
+        }
+        SignatureHelpRequest::METHOD => {
+            respond(req.id, req.params, |p| signature_help::handle(state, &p))
+        }
+        Formatting::METHOD => respond(req.id, req.params, |p| formatting::handle(state, &p)),
+        SemanticTokensFullRequest::METHOD => {
+            respond(req.id, req.params, |p| semantic_tokens::handle(state, &p))
+        }
+        _ => Response::new_err(
+            req.id,
+            ErrorCode::MethodNotFound as i32,
+            format!("unhandled method `{}`", req.method),
+        ),
+    }
+}
+
+/// Deserialize params, run the handler, serialize the (optional)
+/// result. `None` results serialize to JSON `null` — the protocol's
+/// "no answer" for every request this server implements.
+fn respond<P, R>(
+    id: RequestId,
+    params: serde_json::Value,
+    f: impl FnOnce(P) -> Option<R>,
+) -> Response
+where
+    P: serde::de::DeserializeOwned,
+    R: serde::Serialize,
+{
+    let Ok(params) = serde_json::from_value::<P>(params) else {
+        return Response::new_err(
+            id,
+            ErrorCode::InvalidParams as i32,
+            "malformed params".to_string(),
+        );
+    };
+    match serde_json::to_value(f(params)) {
+        Ok(value) => Response::new_ok(id, value),
+        Err(e) => Response::new_err(id, ErrorCode::InternalError as i32, e.to_string()),
+    }
+}
+
+/// Handle one client notification; returns the notifications (fresh
+/// diagnostics) the server should send back.
+pub fn handle_notification(state: &mut ServerState, not: Notification) -> Vec<Notification> {
+    match not.method.as_str() {
+        DidOpenTextDocument::METHOD => parsed::<DidOpenTextDocumentParams>(not.params)
+            .map_or_else(Vec::new, |p| did_open(state, p)),
+        DidChangeTextDocument::METHOD => parsed::<DidChangeTextDocumentParams>(not.params)
+            .map_or_else(Vec::new, |p| did_change(state, p)),
+        DidCloseTextDocument::METHOD => parsed::<DidCloseTextDocumentParams>(not.params)
+            .map_or_else(Vec::new, |p| did_close(state, &p)),
+        _ => Vec::new(),
+    }
+}
+
+/// Malformed params are a client bug; drop the message rather than
+/// crash the server over it.
+fn parsed<T: serde::de::DeserializeOwned>(params: serde_json::Value) -> Option<T> {
+    serde_json::from_value(params).ok()
+}
+
+/// Canonical filesystem key for a document URI — must match the
+/// canonical paths the module resolver produces for `use` targets so
+/// the overlay loader finds open buffers. Falls back to the raw path
+/// for files that don't exist on disk yet.
+fn doc_key(uri: &Uri) -> Option<PathBuf> {
+    let path = uri_to_path(uri)?;
+    Some(fs::canonicalize(&path).unwrap_or(path))
+}
+
+fn refresh_last_good(doc: &mut Document) {
+    if let Ok(program) = keron_lang::parse(&doc.text) {
+        doc.last_good = Some(LastGood {
+            program,
+            text: doc.text.clone(),
+            line_index: doc.line_index.clone(),
+        });
+    }
+}
+
+fn did_open(state: &mut ServerState, params: DidOpenTextDocumentParams) -> Vec<Notification> {
+    let Some(key) = doc_key(&params.text_document.uri) else {
+        return Vec::new();
+    };
+    let text = params.text_document.text;
+    let mut doc = Document {
+        uri: params.text_document.uri,
+        version: params.text_document.version,
+        line_index: LineIndex::new(&text),
+        text,
+        last_good: None,
+    };
+    refresh_last_good(&mut doc);
+    state.docs.insert(key, doc);
+    publish_notifications(analyze(state))
+}
+
+fn did_change(state: &mut ServerState, params: DidChangeTextDocumentParams) -> Vec<Notification> {
+    let Some(key) = doc_key(&params.text_document.uri) else {
+        return Vec::new();
+    };
+    let Some(doc) = state.docs.get_mut(&key) else {
+        return Vec::new();
+    };
+    // Full-text sync: the last change event carries the whole buffer.
+    let Some(change) = params.content_changes.into_iter().next_back() else {
+        return Vec::new();
+    };
+    doc.text = change.text;
+    doc.version = params.text_document.version;
+    doc.line_index = LineIndex::new(&doc.text);
+    refresh_last_good(doc);
+    publish_notifications(analyze(state))
+}
+
+fn did_close(state: &mut ServerState, params: &DidCloseTextDocumentParams) -> Vec<Notification> {
+    let Some(key) = doc_key(&params.text_document.uri) else {
+        return Vec::new();
+    };
+    if state.docs.remove(&key).is_none() {
+        return Vec::new();
+    }
+    publish_notifications(analyze(state))
+}
+
+fn publish_notifications(payloads: Vec<PublishDiagnosticsParams>) -> Vec<Notification> {
+    payloads
+        .into_iter()
+        .map(|p| Notification::new(PublishDiagnostics::METHOD.to_string(), p))
+        .collect()
+}

--- a/crates/keron-lsp/src/handlers/render.rs
+++ b/crates/keron-lsp/src/handlers/render.rs
@@ -1,0 +1,152 @@
+//! Shared plain-text rendering of declarations and signatures, used
+//! by hover, completion details, and signature help. All output is
+//! keron surface syntax (via `Display for Type`), never Rust debug
+//! formatting.
+
+use keron_lang::{FnDecl, FnSig, ParamSig, StructDecl, TypeAliasDecl, ValDecl};
+
+/// `fn name(p: T, q: U = …): Ret` from a parsed declaration.
+#[must_use]
+pub fn fn_decl_signature(f: &FnDecl) -> String {
+    let params: Vec<String> = f
+        .params
+        .iter()
+        .map(|p| {
+            let mut s = format!("{}: {}", p.name.node, p.ty.node);
+            if p.default.is_some() {
+                s.push_str(" = …");
+            }
+            s
+        })
+        .collect();
+    format!(
+        "fn {}({}): {}",
+        f.name.node,
+        params.join(", "),
+        f.return_type.node
+    )
+}
+
+/// Signature text for a checker-level [`FnSig`] (imports + builtins).
+/// Struct constructors render in the brace-literal shape they are
+/// actually written in.
+#[must_use]
+pub fn fn_sig_signature(name: &str, sig: &FnSig) -> String {
+    if let Some(struct_name) = &sig.struct_name {
+        let fields: Vec<String> = sig.params.iter().map(param_label).collect();
+        return format!("struct {struct_name} {{ {} }}", fields.join(", "));
+    }
+    let params: Vec<String> = sig.params.iter().map(param_label).collect();
+    format!("fn {name}({}): {}", params.join(", "), sig.return_type)
+}
+
+/// `name: Type` (with a `= …` marker for defaulted params) — the unit
+/// signature help highlights.
+#[must_use]
+pub fn param_label(p: &ParamSig) -> String {
+    let mut s = format!("{}: {}", p.name, p.ty);
+    if p.has_default {
+        s.push_str(" = …");
+    }
+    s
+}
+
+/// `struct Name { field: T, … }` from a parsed declaration.
+#[must_use]
+pub fn struct_decl_signature(s: &StructDecl) -> String {
+    let fields: Vec<String> = s
+        .fields
+        .iter()
+        .map(|f| {
+            let mut t = format!("{}: {}", f.name.node, f.ty.node);
+            if f.default.is_some() {
+                t.push_str(" = …");
+            }
+            t
+        })
+        .collect();
+    format!("struct {} {{ {} }}", s.name.node, fields.join(", "))
+}
+
+/// `type Name = "a" | "b"` from a parsed declaration.
+#[must_use]
+pub fn type_alias_signature(t: &TypeAliasDecl) -> String {
+    let variants: Vec<String> = t
+        .variants
+        .iter()
+        .map(|v| format!("\"{}\"", v.node))
+        .collect();
+    format!("type {} = {}", t.name.node, variants.join(" | "))
+}
+
+/// `val name: Type`, or just `val name` when unannotated (the LSP does
+/// not re-run inference).
+#[must_use]
+pub fn val_decl_signature(v: &ValDecl) -> String {
+    v.ty.as_ref().map_or_else(
+        || format!("val {}", v.name.node),
+        |ty| format!("val {}: {}", v.name.node, ty.node),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use keron_lang::{Item, parse};
+
+    fn first_fn(src: &str) -> FnDecl {
+        let program = parse(src).expect("fixture parses");
+        program
+            .items
+            .into_iter()
+            .find_map(|i| match i {
+                Item::Fn(f) => Some(f),
+                _ => None,
+            })
+            .expect("has fn")
+    }
+
+    #[test]
+    fn renders_fn_with_default_marker() {
+        let f = first_fn("fn greet(who: String, punct: String = \"!\"): String { who + punct }");
+        assert_eq!(
+            fn_decl_signature(&f),
+            "fn greet(who: String, punct: String = …): String"
+        );
+    }
+
+    #[test]
+    fn renders_struct_and_alias() {
+        let program = parse("struct P { x: Int, y: Int = 0 }\ntype C = \"red\" | \"blue\"\n")
+            .expect("parses");
+        let mut rendered = Vec::new();
+        for item in &program.items {
+            match item {
+                Item::Struct(s) => rendered.push(struct_decl_signature(s)),
+                Item::TypeAlias(t) => rendered.push(type_alias_signature(t)),
+                _ => {}
+            }
+        }
+        assert_eq!(
+            rendered,
+            vec![
+                "struct P { x: Int, y: Int = … }".to_string(),
+                "type C = \"red\" | \"blue\"".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn renders_val_with_and_without_annotation() {
+        let program = parse("val a: Int = 1\nval b = 2\n").expect("parses");
+        let vals: Vec<String> = program
+            .items
+            .iter()
+            .filter_map(|i| match i {
+                Item::Val(v) => Some(val_decl_signature(v)),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(vals, vec!["val a: Int".to_string(), "val b".to_string()]);
+    }
+}

--- a/crates/keron-lsp/src/handlers/semantic_tokens.rs
+++ b/crates/keron-lsp/src/handlers/semantic_tokens.rs
@@ -1,0 +1,240 @@
+//! `textDocument/semanticTokens/full` — syntax highlighting.
+//!
+//! Two layers: the error-tolerant lexical scanner
+//! (`keron_lang::lex_tokens`) colors keywords / strings / numbers /
+//! comments / operators on *any* buffer, and — when the buffer
+//! currently parses — an AST overlay classifies identifiers precisely
+//! (function vs type vs parameter vs property). Mid-edit buffers keep
+//! lexical colors and fall back to name-based identifier
+//! classification, so highlighting never flickers off while typing.
+
+use std::collections::HashMap;
+
+use keron_lang::{Expr, Item, LexTokenKind, Program, lex_tokens};
+use lsp_types::{SemanticToken, SemanticTokenType, SemanticTokens, SemanticTokensParams};
+
+use crate::analysis::node_at::walk_exprs;
+use crate::state::ServerState;
+
+/// The legend advertised in the server capabilities. Index positions
+/// are the `token_type` values encoded below — keep the two in sync
+/// by construction (both read this constant).
+pub const TOKEN_TYPES: [SemanticTokenType; 10] = [
+    SemanticTokenType::KEYWORD,
+    SemanticTokenType::COMMENT,
+    SemanticTokenType::STRING,
+    SemanticTokenType::NUMBER,
+    SemanticTokenType::OPERATOR,
+    SemanticTokenType::FUNCTION,
+    SemanticTokenType::TYPE,
+    SemanticTokenType::VARIABLE,
+    SemanticTokenType::PARAMETER,
+    SemanticTokenType::PROPERTY,
+];
+
+const KEYWORD: u32 = 0;
+const COMMENT: u32 = 1;
+const STRING: u32 = 2;
+const NUMBER: u32 = 3;
+const OPERATOR: u32 = 4;
+const FUNCTION: u32 = 5;
+const TYPE: u32 = 6;
+const VARIABLE: u32 = 7;
+const PARAMETER: u32 = 8;
+const PROPERTY: u32 = 9;
+
+pub fn handle(state: &ServerState, params: &SemanticTokensParams) -> Option<SemanticTokens> {
+    let (_, doc) = state.doc_by_uri(&params.text_document.uri)?;
+    let text = &doc.text;
+    let overlay = doc
+        .last_good
+        .as_ref()
+        // AST spans are only valid against the exact text they were
+        // parsed from; skip the overlay mid-edit.
+        .filter(|lg| lg.text == *text)
+        .map(|lg| IdentClassifier::new(&lg.program));
+
+    let mut spans: Vec<(usize, usize, u32)> = Vec::new();
+    for token in lex_tokens(text) {
+        let token_type = match token.kind {
+            LexTokenKind::Comment => COMMENT,
+            LexTokenKind::Str => STRING,
+            LexTokenKind::Number => NUMBER,
+            LexTokenKind::Keyword => KEYWORD,
+            LexTokenKind::Operator => OPERATOR,
+            LexTokenKind::BuiltinType => TYPE,
+            LexTokenKind::Punct => continue,
+            LexTokenKind::Ident => {
+                let name = &text[token.span.clone()];
+                overlay.as_ref().map_or(VARIABLE, |c| {
+                    c.classify(token.span.start, token.span.end, name)
+                })
+            }
+        };
+        spans.push((token.span.start, token.span.end, token_type));
+    }
+    Some(SemanticTokens {
+        result_id: None,
+        data: encode(text, &spans),
+    })
+}
+
+/// Identifier classification from the parsed AST: an exact span map
+/// for declaration/reference sites the walker visits, plus a name map
+/// for everything else (type annotations, builtin references).
+struct IdentClassifier {
+    by_span: HashMap<(usize, usize), u32>,
+    by_name: HashMap<String, u32>,
+}
+
+impl IdentClassifier {
+    fn new(program: &Program) -> Self {
+        let mut by_span: HashMap<(usize, usize), u32> = HashMap::new();
+        let mut by_name: HashMap<String, u32> = HashMap::new();
+
+        // Builtins first so module-local declarations override them.
+        for module in keron_modules::stdlib::registry().values() {
+            for name in module.fns.keys() {
+                by_name.insert(name.clone(), FUNCTION);
+            }
+            for name in module.types.keys() {
+                by_name.insert(name.clone(), TYPE);
+            }
+        }
+
+        for item in &program.items {
+            match item {
+                Item::Fn(f) => {
+                    by_span.insert(span_key(&f.name.span), FUNCTION);
+                    by_name.insert(f.name.node.clone(), FUNCTION);
+                    for p in &f.params {
+                        by_span.insert(span_key(&p.name.span), PARAMETER);
+                    }
+                }
+                Item::Val(v) => {
+                    by_span.insert(span_key(&v.name.span), VARIABLE);
+                }
+                Item::Struct(s) => {
+                    by_span.insert(span_key(&s.name.span), TYPE);
+                    by_name.insert(s.name.node.clone(), TYPE);
+                    for f in &s.fields {
+                        by_span.insert(span_key(&f.name.span), PROPERTY);
+                    }
+                }
+                Item::TypeAlias(t) => {
+                    by_span.insert(span_key(&t.name.span), TYPE);
+                    by_name.insert(t.name.node.clone(), TYPE);
+                }
+                Item::Use(_) | Item::Reconcile(_) | Item::ExprStmt(_) => {}
+            }
+        }
+
+        walk_exprs(program, &mut |e| match &e.node {
+            Expr::Call { callee, .. } => {
+                by_span.insert(span_key(&callee.span), FUNCTION);
+            }
+            Expr::StructLiteral { name, fields } => {
+                by_span.insert(span_key(&name.span), TYPE);
+                for f in fields {
+                    if f.value.is_some() {
+                        by_span.insert(span_key(&f.name.span), PROPERTY);
+                    }
+                }
+            }
+            Expr::Field { field, .. } => {
+                by_span.insert(span_key(&field.span), PROPERTY);
+            }
+            _ => {}
+        });
+
+        Self { by_span, by_name }
+    }
+
+    fn classify(&self, start: usize, end: usize, name: &str) -> u32 {
+        self.by_span
+            .get(&(start, end))
+            .or_else(|| self.by_name.get(name))
+            .copied()
+            .unwrap_or(VARIABLE)
+    }
+}
+
+const fn span_key(span: &keron_lang::Span) -> (usize, usize) {
+    (span.start, span.end)
+}
+
+/// Delta-encode into the LSP wire format. Tokens spanning multiple
+/// lines (multiline strings) are split per line, because not every
+/// client supports multiline tokens.
+fn encode(text: &str, spans: &[(usize, usize, u32)]) -> Vec<SemanticToken> {
+    let index = crate::line_index::LineIndex::new(text);
+    let mut data = Vec::new();
+    let (mut prev_line, mut prev_char) = (0u32, 0u32);
+    for &(start, end, token_type) in spans {
+        for (seg_start, seg_end) in split_lines(text, start, end) {
+            let start_pos = index.position(text, seg_start);
+            let end_pos = index.position(text, seg_end);
+            let length = end_pos.character.saturating_sub(start_pos.character);
+            if length == 0 {
+                continue;
+            }
+            let delta_line = start_pos.line - prev_line;
+            let delta_start = if delta_line == 0 {
+                start_pos.character - prev_char
+            } else {
+                start_pos.character
+            };
+            data.push(SemanticToken {
+                delta_line,
+                delta_start,
+                length,
+                token_type,
+                token_modifiers_bitset: 0,
+            });
+            (prev_line, prev_char) = (start_pos.line, start_pos.character);
+        }
+    }
+    data
+}
+
+fn split_lines(text: &str, start: usize, end: usize) -> Vec<(usize, usize)> {
+    let mut segments = Vec::new();
+    let mut seg_start = start;
+    for (i, b) in text[start..end].bytes().enumerate() {
+        if b == b'\n' {
+            segments.push((seg_start, start + i));
+            seg_start = start + i + 1;
+        }
+    }
+    segments.push((seg_start, end));
+    segments.retain(|(s, e)| e > s);
+    segments
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn split_lines_handles_multiline_span() {
+        let text = "ab\ncd\nef";
+        assert_eq!(split_lines(text, 0, 8), vec![(0, 2), (3, 5), (6, 8)]);
+        assert_eq!(split_lines(text, 0, 2), vec![(0, 2)]);
+        // Span ending exactly on the newline produces no empty segment.
+        assert_eq!(split_lines(text, 0, 3), vec![(0, 2)]);
+    }
+
+    #[test]
+    fn classifier_prefers_span_over_name() {
+        let program = keron_lang::parse("fn f(): Int { 1 }\nval f2: Int = f()\n").unwrap();
+        let c = IdentClassifier::new(&program);
+        // Callee reference classified as function via span map.
+        let src = "fn f(): Int { 1 }\nval f2: Int = f()\n";
+        let call = src.rfind("f()").unwrap();
+        assert_eq!(c.classify(call, call + 1, "f"), FUNCTION);
+        // Unknown identifier falls back to variable.
+        assert_eq!(c.classify(999, 1000, "mystery"), VARIABLE);
+        // Builtin known by name.
+        assert_eq!(c.classify(999, 1000, "symlink"), FUNCTION);
+    }
+}

--- a/crates/keron-lsp/src/handlers/signature_help.rs
+++ b/crates/keron-lsp/src/handlers/signature_help.rs
@@ -1,0 +1,93 @@
+//! `textDocument/signatureHelp` — parameter hints inside a call's
+//! argument list, with named arguments mapped to their parameter.
+
+use keron_lang::{FnSig, ParamSig, Program};
+use lsp_types::{
+    Documentation, ParameterInformation, ParameterLabel, SignatureHelp, SignatureHelpParams,
+    SignatureInformation,
+};
+
+use crate::analysis::node_at::{CallCtx, enclosing_call};
+use crate::analysis::symbols::{LocalDef, find_local_def};
+use crate::handlers::render;
+use crate::handlers::snapshot_at;
+use crate::state::ServerState;
+
+pub fn handle(state: &ServerState, params: &SignatureHelpParams) -> Option<SignatureHelp> {
+    let pos = &params.text_document_position_params;
+    let snap = snapshot_at(state, &pos.text_document.uri)?;
+    let offset = snap.index.offset(snap.text, pos.position)?;
+    let ctx = enclosing_call(snap.program, offset)?;
+    let sig = resolve_sig(
+        snap.program,
+        &ctx.callee.node,
+        offset,
+        &snap.imported_symbols(),
+    )?;
+
+    let label = render::fn_sig_signature(&ctx.callee.node, &sig);
+    let parameters: Vec<ParameterInformation> = sig
+        .params
+        .iter()
+        .map(|p| ParameterInformation {
+            label: ParameterLabel::Simple(render::param_label(p)),
+            documentation: None,
+        })
+        .collect();
+    let active_parameter = active_param(&ctx, &sig.params);
+    Some(SignatureHelp {
+        signatures: vec![SignatureInformation {
+            label,
+            documentation: None::<Documentation>,
+            parameters: Some(parameters),
+            active_parameter,
+        }],
+        active_signature: Some(0),
+        active_parameter,
+    })
+}
+
+/// The callee's signature: a local fn/struct converted on the fly, or
+/// an imported/builtin [`FnSig`].
+fn resolve_sig(
+    program: &Program,
+    name: &str,
+    offset: usize,
+    imported: &keron_lang::ImportedSymbols,
+) -> Option<FnSig> {
+    match find_local_def(program, name, offset) {
+        Some(LocalDef::Fn(f)) => {
+            return Some(FnSig {
+                struct_name: None,
+                params: f
+                    .params
+                    .iter()
+                    .map(|p| ParamSig {
+                        name: p.name.node.clone(),
+                        ty: p.ty.node.clone(),
+                        has_default: p.default.is_some(),
+                    })
+                    .collect(),
+                return_type: f.return_type.node.clone(),
+            });
+        }
+        Some(LocalDef::Struct(_)) | None => {}
+        _ => return None,
+    }
+    imported.fns.get(name).cloned()
+}
+
+/// Named arguments select their parameter by name; positional ones by
+/// position. Past-the-end positions clamp to the last parameter.
+fn active_param(ctx: &CallCtx<'_>, params: &[ParamSig]) -> Option<u32> {
+    if params.is_empty() {
+        return None;
+    }
+    let index = ctx
+        .args
+        .get(ctx.active)
+        .and_then(|arg| arg.name.as_ref())
+        .and_then(|n| params.iter().position(|p| p.name == n.node))
+        .unwrap_or_else(|| ctx.active.min(params.len() - 1));
+    u32::try_from(index).ok()
+}

--- a/crates/keron-lsp/src/lib.rs
+++ b/crates/keron-lsp/src/lib.rs
@@ -1,0 +1,112 @@
+//! keron-lsp: a synchronous Language Server for keron.
+//!
+//! Transport is `lsp-server` (the rust-analyzer stack) over stdio —
+//! **stdout belongs to the protocol**; never print to it. Analysis is
+//! fully synchronous per change: keron modules are dotfile-sized, so a
+//! whole-workspace re-resolve (parse + import resolution + type check)
+//! completes in well under a frame and the single-threaded main loop
+//! needs no debounce, no snapshots, no cancellation.
+//!
+//! Layering:
+//! - [`state`]: open documents + last-good parse snapshots + the most
+//!   recent module-graph resolution.
+//! - [`analysis`]: overlay file loader + `resolve_with_loader` +
+//!   publish-delta computation.
+//! - [`handlers`]: pure request/notification handlers over the state.
+
+mod analysis;
+mod handlers;
+mod line_index;
+mod state;
+mod uri;
+
+use anyhow::Result;
+use lsp_server::{Connection, Message};
+use lsp_types::{
+    CompletionOptions, HoverProviderCapability, OneOf, PositionEncodingKind,
+    SemanticTokensFullOptions, SemanticTokensLegend, SemanticTokensOptions,
+    SemanticTokensServerCapabilities, ServerCapabilities, SignatureHelpOptions,
+    TextDocumentSyncCapability, TextDocumentSyncKind,
+};
+
+use state::ServerState;
+
+/// Run the language server over stdio until the client disconnects or
+/// sends `exit`. This call blocks; it is the whole body of
+/// `keron lsp`.
+///
+/// # Errors
+/// Returns transport-level failures (broken pipe, protocol violation
+/// during the initialize handshake). A clean client shutdown is `Ok`.
+pub fn run_stdio_server() -> Result<()> {
+    let (connection, io_threads) = Connection::stdio();
+    let result = run_with_connection(&connection);
+    // The writer thread only exits once every channel sender is gone;
+    // dropping the connection before joining is what lets the process
+    // terminate after the client's `exit` notification.
+    drop(connection);
+    io_threads.join()?;
+    result
+}
+
+/// Run the server on an arbitrary connection — the in-memory seam the
+/// end-to-end tests use via `Connection::memory()`.
+///
+/// # Errors
+/// Same contract as [`run_stdio_server`].
+pub fn run_with_connection(connection: &Connection) -> Result<()> {
+    let capabilities = serde_json::to_value(server_capabilities())?;
+    connection.initialize(capabilities)?;
+    main_loop(connection)
+}
+
+fn server_capabilities() -> ServerCapabilities {
+    ServerCapabilities {
+        position_encoding: Some(PositionEncodingKind::UTF16),
+        text_document_sync: Some(TextDocumentSyncCapability::Kind(TextDocumentSyncKind::FULL)),
+        hover_provider: Some(HoverProviderCapability::Simple(true)),
+        completion_provider: Some(CompletionOptions::default()),
+        definition_provider: Some(OneOf::Left(true)),
+        document_symbol_provider: Some(OneOf::Left(true)),
+        document_formatting_provider: Some(OneOf::Left(true)),
+        signature_help_provider: Some(SignatureHelpOptions {
+            trigger_characters: Some(vec!["(".to_string(), ",".to_string()]),
+            retrigger_characters: None,
+            work_done_progress_options: lsp_types::WorkDoneProgressOptions::default(),
+        }),
+        semantic_tokens_provider: Some(SemanticTokensServerCapabilities::SemanticTokensOptions(
+            SemanticTokensOptions {
+                legend: SemanticTokensLegend {
+                    token_types: handlers::semantic_tokens::TOKEN_TYPES.to_vec(),
+                    token_modifiers: Vec::new(),
+                },
+                full: Some(SemanticTokensFullOptions::Bool(true)),
+                range: None,
+                work_done_progress_options: lsp_types::WorkDoneProgressOptions::default(),
+            },
+        )),
+        ..Default::default()
+    }
+}
+
+fn main_loop(connection: &Connection) -> Result<()> {
+    let mut state = ServerState::default();
+    for msg in &connection.receiver {
+        match msg {
+            Message::Request(req) => {
+                if connection.handle_shutdown(&req)? {
+                    return Ok(());
+                }
+                let response = handlers::handle_request(&state, req);
+                connection.sender.send(Message::Response(response))?;
+            }
+            Message::Notification(not) => {
+                for out in handlers::handle_notification(&mut state, not) {
+                    connection.sender.send(Message::Notification(out))?;
+                }
+            }
+            Message::Response(_) => {}
+        }
+    }
+    Ok(())
+}

--- a/crates/keron-lsp/src/line_index.rs
+++ b/crates/keron-lsp/src/line_index.rs
@@ -1,0 +1,197 @@
+//! Byte-offset ⇄ LSP position conversion.
+//!
+//! keron spans are byte ranges into UTF-8 source; the LSP wire format
+//! speaks zero-based line numbers plus UTF-16 code-unit columns (the
+//! only encoding every client must support — the server advertises
+//! `PositionEncodingKind::UTF16`). [`LineIndex`] precomputes line
+//! starts once per document version so each conversion only scans a
+//! single line.
+
+use lsp_types::Position;
+
+use keron_lang::Span;
+
+/// Byte offsets of every line start in one document snapshot. Valid
+/// only for the exact text it was built from — rebuild on every edit.
+#[derive(Debug, Clone)]
+pub struct LineIndex {
+    /// `line_starts[i]` is the byte offset where line `i` begins;
+    /// `line_starts[0] == 0` always, even for empty text.
+    line_starts: Vec<usize>,
+}
+
+impl LineIndex {
+    #[must_use]
+    pub fn new(text: &str) -> Self {
+        let mut line_starts = vec![0];
+        line_starts.extend(
+            text.bytes()
+                .enumerate()
+                .filter(|&(_, b)| b == b'\n')
+                .map(|(i, _)| i + 1),
+        );
+        Self { line_starts }
+    }
+
+    /// Convert a byte offset into `text` (the text this index was
+    /// built from) to an LSP UTF-16 position. Offsets past the end of
+    /// the text clamp to the final position; offsets inside a
+    /// multi-byte character round down to that character's start.
+    #[must_use]
+    pub fn position(&self, text: &str, offset: usize) -> Position {
+        let offset = clamp_to_char_boundary(text, offset);
+        let line = self
+            .line_starts
+            .partition_point(|&start| start <= offset)
+            .saturating_sub(1);
+        let line_start = self.line_starts[line];
+        let character = text[line_start..offset]
+            .chars()
+            .map(char::len_utf16)
+            .sum::<usize>();
+        Position {
+            line: u32::try_from(line).unwrap_or(u32::MAX),
+            character: u32::try_from(character).unwrap_or(u32::MAX),
+        }
+    }
+
+    /// Convert an LSP span into an `lsp_types::Range`.
+    #[must_use]
+    pub fn range(&self, text: &str, span: &Span) -> lsp_types::Range {
+        lsp_types::Range {
+            start: self.position(text, span.start),
+            end: self.position(text, span.end),
+        }
+    }
+
+    /// Convert an LSP UTF-16 position back to a byte offset into
+    /// `text`. A `character` beyond the end of its line clamps to the
+    /// line end (LSP-specified behavior); a `line` beyond the last
+    /// line returns `None`.
+    #[must_use]
+    pub fn offset(&self, text: &str, position: Position) -> Option<usize> {
+        let line_start = *self.line_starts.get(position.line as usize)?;
+        let line_end = self
+            .line_starts
+            .get(position.line as usize + 1)
+            .map_or(text.len(), |&next| next - 1);
+        let line_text = &text[line_start..line_end];
+        let mut units_left = position.character as usize;
+        for (i, c) in line_text.char_indices() {
+            if units_left < c.len_utf16() {
+                return Some(line_start + i);
+            }
+            units_left -= c.len_utf16();
+        }
+        Some(line_end)
+    }
+
+    /// The position one past the last character — the exclusive end of
+    /// a whole-document range (used by full-text formatting edits).
+    #[must_use]
+    pub fn end_position(&self, text: &str) -> Position {
+        self.position(text, text.len())
+    }
+}
+
+fn clamp_to_char_boundary(text: &str, mut offset: usize) -> usize {
+    offset = offset.min(text.len());
+    while offset > 0 && !text.is_char_boundary(offset) {
+        offset -= 1;
+    }
+    offset
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use proptest::prelude::*;
+
+    fn pos(line: u32, character: u32) -> Position {
+        Position { line, character }
+    }
+
+    #[test]
+    fn ascii_positions() {
+        let text = "ab\ncd\n";
+        let idx = LineIndex::new(text);
+        assert_eq!(idx.position(text, 0), pos(0, 0));
+        assert_eq!(idx.position(text, 2), pos(0, 2));
+        assert_eq!(idx.position(text, 3), pos(1, 0));
+        assert_eq!(idx.position(text, 5), pos(1, 2));
+        assert_eq!(idx.position(text, 6), pos(2, 0));
+    }
+
+    #[test]
+    fn multibyte_counts_utf16_units() {
+        // 'é' = 2 bytes / 1 UTF-16 unit; '🎉' = 4 bytes / 2 units.
+        let text = "é🎉x";
+        let idx = LineIndex::new(text);
+        assert_eq!(idx.position(text, 2), pos(0, 1));
+        assert_eq!(idx.position(text, 6), pos(0, 3));
+        assert_eq!(idx.offset(text, pos(0, 1)), Some(2));
+        assert_eq!(idx.offset(text, pos(0, 3)), Some(6));
+    }
+
+    #[test]
+    fn offset_inside_multibyte_char_rounds_down() {
+        let text = "🎉";
+        let idx = LineIndex::new(text);
+        assert_eq!(idx.position(text, 2), pos(0, 0));
+    }
+
+    #[test]
+    fn crlf_newline_is_part_of_previous_line() {
+        let text = "ab\r\ncd";
+        let idx = LineIndex::new(text);
+        assert_eq!(idx.position(text, 4), pos(1, 0));
+        assert_eq!(idx.position(text, 2), pos(0, 2));
+        assert_eq!(idx.offset(text, pos(1, 0)), Some(4));
+    }
+
+    #[test]
+    fn character_past_line_end_clamps_to_line_end() {
+        let text = "ab\ncd";
+        let idx = LineIndex::new(text);
+        assert_eq!(idx.offset(text, pos(0, 99)), Some(2));
+        assert_eq!(idx.offset(text, pos(1, 99)), Some(5));
+    }
+
+    #[test]
+    fn line_past_end_returns_none() {
+        let text = "ab";
+        let idx = LineIndex::new(text);
+        assert_eq!(idx.offset(text, pos(5, 0)), None);
+    }
+
+    #[test]
+    fn empty_text_has_one_line() {
+        let text = "";
+        let idx = LineIndex::new(text);
+        assert_eq!(idx.position(text, 0), pos(0, 0));
+        assert_eq!(idx.offset(text, pos(0, 0)), Some(0));
+        assert_eq!(idx.end_position(text), pos(0, 0));
+    }
+
+    proptest! {
+        #[test]
+        fn roundtrip_offset_position_offset(text in "\\PC*(\n\\PC*){0,5}", frac in 0usize..10_000) {
+            // Pick an arbitrary char boundary and require an exact
+            // roundtrip through Position.
+            let mut offset = frac % (text.len() + 1);
+            while offset > 0 && !text.is_char_boundary(offset) {
+                offset -= 1;
+            }
+            let idx = LineIndex::new(&text);
+            let position = idx.position(&text, offset);
+            prop_assert_eq!(idx.offset(&text, position), Some(offset));
+        }
+
+        #[test]
+        fn position_is_total_and_offset_never_panics(text in ".*", offset in 0usize..200) {
+            let idx = LineIndex::new(&text);
+            let position = idx.position(&text, offset);
+            let _ = idx.offset(&text, position);
+        }
+    }
+}

--- a/crates/keron-lsp/src/state.rs
+++ b/crates/keron-lsp/src/state.rs
@@ -1,0 +1,59 @@
+//! In-memory server state: open documents, last-good parse snapshots,
+//! the latest module-graph resolution, and publish bookkeeping.
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+use keron_lang::Program;
+use keron_modules::Resolution;
+use lsp_types::Uri;
+
+use crate::line_index::LineIndex;
+
+/// One open editor document. Keyed in [`ServerState::docs`] by its
+/// canonicalized filesystem path (the same key the module resolver
+/// uses), so overlay lookups and diagnostic fan-out agree on identity.
+#[derive(Debug)]
+pub struct Document {
+    pub uri: Uri,
+    pub version: i32,
+    pub text: String,
+    pub line_index: LineIndex,
+    /// The most recent snapshot whose parse succeeded. Feature
+    /// requests (hover, completion, symbols) fall back to this while
+    /// the live text is mid-edit and unparseable; spans in
+    /// `last_good.program` are only valid against `last_good.text`.
+    pub last_good: Option<LastGood>,
+}
+
+/// A parseable snapshot of a document, kept alongside the exact text
+/// and line index its spans refer to.
+#[derive(Debug)]
+pub struct LastGood {
+    pub program: Program,
+    pub text: String,
+    pub line_index: LineIndex,
+}
+
+/// Whole-server mutable state, owned by the single-threaded main loop.
+#[derive(Debug, Default)]
+pub struct ServerState {
+    pub docs: HashMap<PathBuf, Document>,
+    /// Result of the most recent [`keron_modules::resolve_with_loader`]
+    /// run over all open documents. Feature handlers read the graph;
+    /// `None` only before the first didOpen.
+    pub resolution: Option<Resolution>,
+    /// Diagnostics published in the previous round, keyed by URI
+    /// string. Lets the next round skip unchanged sets and push empty
+    /// arrays to URIs whose diagnostics disappeared.
+    pub published: HashMap<String, Vec<lsp_types::Diagnostic>>,
+}
+
+impl ServerState {
+    /// Look up the open document backing `uri`, together with its
+    /// canonical path key.
+    #[must_use]
+    pub fn doc_by_uri(&self, uri: &Uri) -> Option<(&PathBuf, &Document)> {
+        self.docs.iter().find(|(_, d)| d.uri == *uri)
+    }
+}

--- a/crates/keron-lsp/src/uri.rs
+++ b/crates/keron-lsp/src/uri.rs
@@ -137,6 +137,9 @@ mod tests {
         Uri::from_str(s).expect("valid test uri")
     }
 
+    // Unix path shapes: `/home/…` has no drive letter, so on Windows
+    // `Path::is_absolute` is false and conversion rightly refuses.
+    #[cfg(unix)]
     #[test]
     fn plain_unix_path_roundtrips() {
         let path = Path::new("/home/user/dots/main.keron");
@@ -145,6 +148,7 @@ mod tests {
         assert_eq!(uri_to_path(&u), Some(path.to_path_buf()));
     }
 
+    #[cfg(unix)]
     #[test]
     fn spaces_and_unicode_percent_encode() {
         let path = Path::new("/home/user/my dots/héllo.keron");

--- a/crates/keron-lsp/src/uri.rs
+++ b/crates/keron-lsp/src/uri.rs
@@ -1,0 +1,233 @@
+//! `file://` URI ⇄ filesystem path conversion.
+//!
+//! lsp-types 0.97 backs [`Uri`] with `fluent-uri`, which (unlike the
+//! old `url` crate) ships no `from_file_path`/`to_file_path` helpers,
+//! so this module hand-rolls the tiny subset the server needs:
+//! percent-encoding of paths going out, percent-decoding of URIs
+//! coming in, and the Windows drive-letter form (`file:///C:/…`).
+//! Only `file` URIs convert; anything else returns `None` and the
+//! server ignores the document.
+
+use std::path::{Path, PathBuf};
+use std::str::FromStr;
+
+use lsp_types::Uri;
+
+/// Convert a `file://` URI to a filesystem path. Returns `None` for
+/// non-`file` schemes, non-local authorities, undecodable escapes, or
+/// non-UTF-8 path bytes.
+#[must_use]
+pub fn uri_to_path(uri: &Uri) -> Option<PathBuf> {
+    let s = uri.as_str();
+    let rest = strip_scheme(s)?;
+    // Split authority from the path at the first `/`.
+    let (authority, raw_path) = rest.find('/').map_or((rest, "/"), |i| rest.split_at(i));
+    if !(authority.is_empty() || authority.eq_ignore_ascii_case("localhost")) {
+        return None;
+    }
+    // file URIs from editors carry no query/fragment; tolerate and
+    // drop them if one ever shows up.
+    let raw_path = raw_path.split(['?', '#']).next().unwrap_or(raw_path);
+    let decoded = percent_decode(raw_path)?;
+    Some(decoded_to_path(&decoded))
+}
+
+/// Convert an absolute filesystem path to a `file://` URI. Returns
+/// `None` for relative or non-UTF-8 paths.
+#[must_use]
+pub fn path_to_uri(path: &Path) -> Option<Uri> {
+    if !path.is_absolute() {
+        return None;
+    }
+    let s = path.to_str()?;
+    let mut out = String::with_capacity(s.len() + 8);
+    out.push_str("file://");
+    if cfg!(windows) {
+        // `fs::canonicalize` on Windows yields verbatim paths
+        // (`\\?\C:\…`); editors speak `file:///C:/…`, so drop the
+        // prefix or published-diagnostic URIs won't match the
+        // client's document URIs.
+        let s = s.strip_prefix(r"\\?\").unwrap_or(s);
+        let normalized = s.replace('\\', "/");
+        // `C:/…` needs the extra root slash: `file:///C:/…`. UNC paths
+        // (`//server/share`) already start with the slashes fluent-uri
+        // expects after the empty authority.
+        if !normalized.starts_with('/') {
+            out.push('/');
+        }
+        percent_encode_into(&mut out, &normalized);
+    } else {
+        percent_encode_into(&mut out, s);
+    }
+    Uri::from_str(&out).ok()
+}
+
+fn strip_scheme(s: &str) -> Option<&str> {
+    let (scheme, rest) = s.split_once("://")?;
+    scheme.eq_ignore_ascii_case("file").then_some(rest)
+}
+
+/// Bytes that travel bare in a URI path: RFC 3986 unreserved plus the
+/// pchar extras that matter for paths (`/`, `:`, `@`, and the
+/// sub-delims that commonly appear in filenames).
+const fn is_bare_path_byte(b: u8) -> bool {
+    b.is_ascii_alphanumeric() || matches!(b, b'-' | b'.' | b'_' | b'~' | b'/' | b':' | b'@' | b'+')
+}
+
+fn percent_encode_into(out: &mut String, s: &str) {
+    for &b in s.as_bytes() {
+        if is_bare_path_byte(b) {
+            out.push(b as char);
+        } else {
+            out.push('%');
+            out.push(char::from_digit(u32::from(b >> 4), 16).expect("nibble < 16"));
+            out.push(
+                char::from_digit(u32::from(b & 0xf), 16)
+                    .expect("nibble < 16")
+                    .to_ascii_uppercase(),
+            );
+        }
+    }
+}
+
+fn percent_decode(s: &str) -> Option<String> {
+    let bytes = s.as_bytes();
+    let mut out = Vec::with_capacity(bytes.len());
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'%' {
+            let hex = bytes.get(i + 1..i + 3)?;
+            let hi = (hex[0] as char).to_digit(16)?;
+            let lo = (hex[1] as char).to_digit(16)?;
+            out.push(u8::try_from(hi * 16 + lo).expect("two hex digits fit u8"));
+            i += 3;
+        } else {
+            out.push(bytes[i]);
+            i += 1;
+        }
+    }
+    String::from_utf8(out).ok()
+}
+
+fn decoded_to_path(decoded: &str) -> PathBuf {
+    if cfg!(windows) {
+        // `/C:/…` (or the legacy `/C|/…`) → `C:/…`.
+        let bytes = decoded.as_bytes();
+        if bytes.len() >= 3
+            && bytes[0] == b'/'
+            && bytes[1].is_ascii_alphabetic()
+            && (bytes[2] == b':' || bytes[2] == b'|')
+        {
+            let mut s = String::with_capacity(decoded.len() - 1);
+            s.push(bytes[1] as char);
+            s.push(':');
+            s.push_str(&decoded[3..]);
+            return PathBuf::from(s);
+        }
+    }
+    PathBuf::from(decoded)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use proptest::prelude::*;
+
+    fn uri(s: &str) -> Uri {
+        Uri::from_str(s).expect("valid test uri")
+    }
+
+    #[test]
+    fn plain_unix_path_roundtrips() {
+        let path = Path::new("/home/user/dots/main.keron");
+        let u = path_to_uri(path).expect("uri");
+        assert_eq!(u.as_str(), "file:///home/user/dots/main.keron");
+        assert_eq!(uri_to_path(&u), Some(path.to_path_buf()));
+    }
+
+    #[test]
+    fn spaces_and_unicode_percent_encode() {
+        let path = Path::new("/home/user/my dots/héllo.keron");
+        let u = path_to_uri(path).expect("uri");
+        assert!(u.as_str().contains("my%20dots"), "got {}", u.as_str());
+        assert_eq!(uri_to_path(&u), Some(path.to_path_buf()));
+    }
+
+    #[test]
+    fn decodes_editor_style_encoded_colon() {
+        // VS Code percent-encodes aggressively; a lowercase escape
+        // must decode the same as uppercase.
+        let u = uri("file:///home/a%2fb%20c");
+        assert_eq!(uri_to_path(&u), Some(PathBuf::from("/home/a/b c")));
+    }
+
+    #[test]
+    fn localhost_authority_is_accepted() {
+        let u = uri("file://localhost/etc/hosts");
+        assert_eq!(uri_to_path(&u), Some(PathBuf::from("/etc/hosts")));
+    }
+
+    #[test]
+    fn remote_authority_is_rejected() {
+        let u = uri("file://example.com/etc/hosts");
+        assert_eq!(uri_to_path(&u), None);
+    }
+
+    #[test]
+    fn non_file_scheme_is_rejected() {
+        let u = uri("untitled:Untitled-1");
+        assert_eq!(uri_to_path(&u), None);
+        let u = uri("https://example.com/x.keron");
+        assert_eq!(uri_to_path(&u), None);
+    }
+
+    #[test]
+    fn relative_path_makes_no_uri() {
+        assert_eq!(path_to_uri(Path::new("relative/x.keron")), None);
+    }
+
+    #[test]
+    fn truncated_percent_escape_is_rejected() {
+        // fluent-uri already rejects `%2` at parse time; the decoder
+        // must also defend on its own for inputs that sneak past.
+        assert_eq!(percent_decode("%2"), None);
+        assert_eq!(percent_decode("ok%GG"), None);
+        assert_eq!(percent_decode("fine%20"), Some("fine ".to_string()));
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn windows_drive_letter_roundtrips() {
+        let path = Path::new(r"C:\Users\me\dots\main.keron");
+        let u = path_to_uri(path).expect("uri");
+        assert_eq!(u.as_str(), "file:///C:/Users/me/dots/main.keron");
+        assert_eq!(
+            uri_to_path(&u),
+            Some(PathBuf::from("C:/Users/me/dots/main.keron"))
+        );
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn windows_encoded_drive_colon_decodes() {
+        let u = uri("file:///c%3A/Users/me/x.keron");
+        assert_eq!(uri_to_path(&u), Some(PathBuf::from("c:/Users/me/x.keron")));
+    }
+
+    proptest! {
+        #[test]
+        fn unix_paths_roundtrip(segments in proptest::collection::vec("[^/\u{0}]{1,12}", 1..5)) {
+            let path = PathBuf::from(format!("/{}", segments.join("/")));
+            if let Some(u) = path_to_uri(&path) {
+                prop_assert_eq!(uri_to_path(&u), Some(path));
+            }
+        }
+
+        #[test]
+        fn uri_to_path_never_panics(s in "file://[ -~]{0,40}") {
+            if let Ok(u) = Uri::from_str(&s) {
+                let _ = uri_to_path(&u);
+            }
+        }
+    }
+}

--- a/crates/keron-lsp/tests/server.rs
+++ b/crates/keron-lsp/tests/server.rs
@@ -1,0 +1,416 @@
+//! End-to-end LSP tests: drive `run_with_connection` over an
+//! in-memory transport exactly the way an editor would over stdio —
+//! initialize handshake, didOpen/didChange, feature requests,
+//! shutdown — and assert on the wire-level payloads.
+
+use std::collections::VecDeque;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::str::FromStr;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::Duration;
+
+use lsp_server::{Connection, Message, Notification, Request, RequestId};
+use lsp_types::notification::{DidChangeTextDocument, DidOpenTextDocument, Notification as _};
+use lsp_types::request::{
+    Formatting, GotoDefinition, HoverRequest, Initialize, Request as _, SemanticTokensFullRequest,
+    Shutdown,
+};
+use lsp_types::{
+    DidChangeTextDocumentParams, DidOpenTextDocumentParams, DocumentFormattingParams,
+    FormattingOptions, GotoDefinitionParams, GotoDefinitionResponse, Hover, HoverContents,
+    HoverParams, InitializeParams, Position, PublishDiagnosticsParams, SemanticTokens,
+    SemanticTokensParams, TextDocumentContentChangeEvent, TextDocumentIdentifier, TextDocumentItem,
+    TextDocumentPositionParams, Uri, VersionedTextDocumentIdentifier, WorkDoneProgressParams,
+};
+
+const TIMEOUT: Duration = Duration::from_secs(10);
+
+static COUNTER: AtomicUsize = AtomicUsize::new(0);
+
+struct TempProject {
+    root: PathBuf,
+}
+
+impl TempProject {
+    fn new(name: &str) -> Self {
+        let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+        let root =
+            std::env::temp_dir().join(format!("keron-lsp-e2e-{name}-{}-{n}", std::process::id()));
+        let _ = fs::remove_dir_all(&root);
+        fs::create_dir_all(&root).expect("create temp dir");
+        Self {
+            root: fs::canonicalize(&root).expect("canonicalize temp dir"),
+        }
+    }
+
+    fn write(&self, rel: &str, content: &str) -> PathBuf {
+        let path = self.root.join(rel);
+        fs::write(&path, content).expect("write file");
+        path
+    }
+}
+
+impl Drop for TempProject {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir_all(&self.root);
+    }
+}
+
+fn file_uri(path: &Path) -> Uri {
+    // Editor-style file URI: forward slashes, no Windows `\\?\`
+    // verbatim prefix, and a leading `/` before the drive letter.
+    let s = path.display().to_string();
+    let s = s.strip_prefix(r"\\?\").unwrap_or(&s).replace('\\', "/");
+    let root = if s.starts_with('/') { "" } else { "/" };
+    Uri::from_str(&format!("file://{root}{s}")).expect("temp paths are uri-safe ascii")
+}
+
+/// A minimal LSP client over `Connection::memory()`. Notifications
+/// that arrive while waiting for a response are buffered so tests can
+/// assert on them later, in order.
+struct Client {
+    conn: Connection,
+    server: Option<std::thread::JoinHandle<()>>,
+    pending: VecDeque<Notification>,
+    next_id: i32,
+}
+
+impl Client {
+    fn start() -> Self {
+        let (server_side, client_side) = Connection::memory();
+        let server = std::thread::spawn(move || {
+            keron_lsp::run_with_connection(&server_side).expect("server run");
+        });
+        let mut client = Self {
+            conn: client_side,
+            server: Some(server),
+            pending: VecDeque::new(),
+            next_id: 0,
+        };
+        let _: serde_json::Value =
+            client.request::<InitializeParams>(Initialize::METHOD, InitializeParams::default());
+        client.notify("initialized", serde_json::json!({}));
+        client
+    }
+
+    fn request<P: serde::Serialize>(&mut self, method: &str, params: P) -> serde_json::Value {
+        self.next_id += 1;
+        let id = RequestId::from(self.next_id);
+        self.conn
+            .sender
+            .send(Message::Request(Request::new(
+                id.clone(),
+                method.to_string(),
+                params,
+            )))
+            .expect("send request");
+        loop {
+            match self.recv() {
+                Message::Response(resp) => {
+                    assert_eq!(resp.id, id, "responses arrive in order");
+                    assert!(resp.error.is_none(), "unexpected error: {:?}", resp.error);
+                    return resp.result.unwrap_or(serde_json::Value::Null);
+                }
+                Message::Notification(n) => self.pending.push_back(n),
+                Message::Request(r) => panic!("server sent unexpected request {}", r.method),
+            }
+        }
+    }
+
+    fn notify<P: serde::Serialize>(&self, method: &str, params: P) {
+        self.conn
+            .sender
+            .send(Message::Notification(Notification::new(
+                method.to_string(),
+                params,
+            )))
+            .expect("send notification");
+    }
+
+    fn recv(&self) -> Message {
+        self.conn
+            .receiver
+            .recv_timeout(TIMEOUT)
+            .expect("server response within timeout")
+    }
+
+    /// Next publishDiagnostics notification (buffered or fresh).
+    fn diagnostics(&mut self) -> PublishDiagnosticsParams {
+        loop {
+            let n = self
+                .pending
+                .pop_front()
+                .unwrap_or_else(|| match self.recv() {
+                    Message::Notification(n) => n,
+                    other => panic!("expected notification, got {other:?}"),
+                });
+            if n.method == "textDocument/publishDiagnostics" {
+                return serde_json::from_value(n.params).expect("valid publish params");
+            }
+        }
+    }
+
+    fn open(&self, uri: &Uri, text: &str) {
+        self.notify(
+            DidOpenTextDocument::METHOD,
+            DidOpenTextDocumentParams {
+                text_document: TextDocumentItem {
+                    uri: uri.clone(),
+                    language_id: "keron".to_string(),
+                    version: 1,
+                    text: text.to_string(),
+                },
+            },
+        );
+    }
+
+    fn change(&self, uri: &Uri, version: i32, text: &str) {
+        self.notify(
+            DidChangeTextDocument::METHOD,
+            DidChangeTextDocumentParams {
+                text_document: VersionedTextDocumentIdentifier {
+                    uri: uri.clone(),
+                    version,
+                },
+                content_changes: vec![TextDocumentContentChangeEvent {
+                    range: None,
+                    range_length: None,
+                    text: text.to_string(),
+                }],
+            },
+        );
+    }
+
+    fn position_params(uri: &Uri, position: Position) -> TextDocumentPositionParams {
+        TextDocumentPositionParams {
+            text_document: TextDocumentIdentifier { uri: uri.clone() },
+            position,
+        }
+    }
+
+    fn shutdown(mut self) {
+        let _ = self.request(Shutdown::METHOD, serde_json::Value::Null);
+        self.notify("exit", serde_json::Value::Null);
+        self.server
+            .take()
+            .expect("server handle")
+            .join()
+            .expect("server thread exits cleanly");
+    }
+}
+
+/// Position of `needle`'s first byte (+ `add` chars) in single-line
+/// terms; the fixtures keep multi-line offsets simple by construction.
+fn pos_of(src: &str, needle: &str, add: u32) -> Position {
+    let offset = src.find(needle).expect("needle present");
+    let line = src[..offset].matches('\n').count();
+    let line_start = src[..offset].rfind('\n').map_or(0, |i| i + 1);
+    let character = u32::try_from(offset - line_start).expect("short lines") + add;
+    Position::new(u32::try_from(line).expect("short files"), character)
+}
+
+#[test]
+fn diagnostics_lifecycle_open_broken_then_fix() {
+    let proj = TempProject::new("diag");
+    let path = proj.write("main.keron", "");
+    let uri = file_uri(&path);
+    let mut client = Client::start();
+
+    client.open(&uri, "val n: Int = \"not an int\"\n");
+    let published = client.diagnostics();
+    assert_eq!(published.uri, uri);
+    assert!(
+        !published.diagnostics.is_empty(),
+        "type error must produce a diagnostic"
+    );
+    let diag = &published.diagnostics[0];
+    assert_eq!(diag.source.as_deref(), Some("keron"));
+    assert!(
+        diag.message.contains("Int"),
+        "message should mention the type: {}",
+        diag.message
+    );
+
+    client.change(&uri, 2, "val n: Int = 1\n");
+    let cleared = client.diagnostics();
+    assert_eq!(cleared.uri, uri);
+    assert!(
+        cleared.diagnostics.is_empty(),
+        "fixed buffer must clear diagnostics"
+    );
+    client.shutdown();
+}
+
+#[test]
+fn hover_shows_builtin_signature() {
+    let proj = TempProject::new("hover");
+    let path = proj.write("main.keron", "");
+    let uri = file_uri(&path);
+    let src = "val s: Symlink = symlink(source = \"a\", target = \"b\")\nreconcile s\n";
+    let mut client = Client::start();
+    client.open(&uri, src);
+
+    let result = client.request(
+        HoverRequest::METHOD,
+        HoverParams {
+            text_document_position_params: Client::position_params(
+                &uri,
+                pos_of(src, "symlink(", 2),
+            ),
+            work_done_progress_params: WorkDoneProgressParams::default(),
+        },
+    );
+    let hover: Hover = serde_json::from_value(result).expect("hover result");
+    let HoverContents::Markup(markup) = hover.contents else {
+        panic!("expected markup hover");
+    };
+    assert!(
+        markup.value.contains("fn symlink(") && markup.value.contains("Symlink"),
+        "builtin signature expected, got: {}",
+        markup.value
+    );
+    client.shutdown();
+}
+
+#[test]
+fn definition_jumps_across_files() {
+    let proj = TempProject::new("defs");
+    let lib = proj.write(
+        "lib.keron",
+        "fn greet(who: String): String { \"hi \" + who }\n",
+    );
+    let main = proj.write("main.keron", "");
+    let main_uri = file_uri(&main);
+    let lib_uri = file_uri(&fs::canonicalize(&lib).expect("lib exists"));
+    let src = "from \"./lib.keron\" use greet\nval g: String = greet(\"you\")\n";
+    let mut client = Client::start();
+    client.open(&main_uri, src);
+
+    let result = client.request(
+        GotoDefinition::METHOD,
+        GotoDefinitionParams {
+            text_document_position_params: Client::position_params(
+                &main_uri,
+                pos_of(src, "greet(\"you\")", 2),
+            ),
+            work_done_progress_params: WorkDoneProgressParams::default(),
+            partial_result_params: lsp_types::PartialResultParams::default(),
+        },
+    );
+    let response: GotoDefinitionResponse =
+        serde_json::from_value(result).expect("definition result");
+    let GotoDefinitionResponse::Scalar(location) = response else {
+        panic!("expected scalar location");
+    };
+    assert_eq!(location.uri, lib_uri, "definition must land in lib.keron");
+    assert_eq!(location.range.start, Position::new(0, 3));
+    client.shutdown();
+}
+
+#[test]
+fn formatting_returns_whole_document_edit() {
+    let proj = TempProject::new("fmt");
+    let path = proj.write("main.keron", "");
+    let uri = file_uri(&path);
+    let mut client = Client::start();
+    client.open(&uri, "val x : Int=1");
+
+    let result = client.request(
+        Formatting::METHOD,
+        DocumentFormattingParams {
+            text_document: TextDocumentIdentifier { uri },
+            options: FormattingOptions::default(),
+            work_done_progress_params: WorkDoneProgressParams::default(),
+        },
+    );
+    let edits: Vec<lsp_types::TextEdit> = serde_json::from_value(result).expect("edits");
+    assert_eq!(edits.len(), 1, "one whole-document edit");
+    assert_eq!(edits[0].new_text, "val x: Int = 1\n");
+    assert_eq!(edits[0].range.start, Position::new(0, 0));
+    client.shutdown();
+}
+
+#[test]
+fn semantic_tokens_cover_keywords_and_functions() {
+    let proj = TempProject::new("tokens");
+    let path = proj.write("main.keron", "");
+    let uri = file_uri(&path);
+    let mut client = Client::start();
+    client.open(
+        &uri,
+        "# comment\nval s: Symlink = symlink(source = \"a\", target = \"b\")\n",
+    );
+
+    let result = client.request(
+        SemanticTokensFullRequest::METHOD,
+        SemanticTokensParams {
+            text_document: TextDocumentIdentifier { uri },
+            work_done_progress_params: WorkDoneProgressParams::default(),
+            partial_result_params: lsp_types::PartialResultParams::default(),
+        },
+    );
+    let tokens: SemanticTokens = serde_json::from_value(result).expect("tokens");
+    assert!(
+        tokens.data.len() >= 8,
+        "expected a full token stream, got {} tokens",
+        tokens.data.len()
+    );
+    // First token: the comment at line 0 col 0 (legend index 1).
+    let first = &tokens.data[0];
+    assert_eq!((first.delta_line, first.delta_start), (0, 0));
+    assert_eq!(first.token_type, 1, "leading comment");
+    // Second token: `val` keyword on the next line (legend index 0).
+    let second = &tokens.data[1];
+    assert_eq!(second.delta_line, 1);
+    assert_eq!(second.token_type, 0, "`val` keyword");
+    assert_eq!(second.length, 3);
+    client.shutdown();
+}
+
+#[test]
+fn unparseable_buffer_still_serves_hover_from_last_good() {
+    let proj = TempProject::new("stale");
+    let path = proj.write("main.keron", "");
+    let uri = file_uri(&path);
+    let src = "val s: Symlink = symlink(source = \"a\", target = \"b\")\nreconcile s\n";
+    let mut client = Client::start();
+    // A clean open publishes nothing (only *changes* are pushed), so
+    // don't wait for diagnostics here.
+    client.open(&uri, src);
+
+    // Break the buffer; diagnostics reflect the broken text.
+    client.change(
+        &uri,
+        2,
+        "val s: Symlink = symlink(source = \nthis is not keron",
+    );
+    let broken = client.diagnostics();
+    assert!(
+        !broken.diagnostics.is_empty(),
+        "broken buffer must produce parse diagnostics"
+    );
+
+    // Hover still answers, served from the last-good snapshot.
+    let result = client.request(
+        HoverRequest::METHOD,
+        HoverParams {
+            text_document_position_params: Client::position_params(
+                &uri,
+                pos_of(src, "symlink(", 2),
+            ),
+            work_done_progress_params: WorkDoneProgressParams::default(),
+        },
+    );
+    let hover: Option<Hover> = serde_json::from_value(result).expect("hover result");
+    let hover = hover.expect("hover from last-good snapshot");
+    let HoverContents::Markup(markup) = hover.contents else {
+        panic!("expected markup hover");
+    };
+    assert!(
+        markup.value.contains("fn symlink("),
+        "got: {}",
+        markup.value
+    );
+    client.shutdown();
+}

--- a/crates/keron-modules/src/lib.rs
+++ b/crates/keron-modules/src/lib.rs
@@ -129,6 +129,47 @@ pub struct EntrySource {
     pub id: ModuleId,
 }
 
+/// Source of module text during dependency resolution. [`resolve`]
+/// reads from disk via [`DiskLoader`]; editor tooling passes an
+/// overlay that prefers open (possibly unsaved) buffers.
+///
+/// Only the *reading* of `use`-imported files goes through this trait.
+/// Path resolution (`fs::canonicalize`, regular-file checks) always
+/// consults the real filesystem, so an import can only target a file
+/// that exists on disk — an overlay changes its *content*, not its
+/// existence.
+pub trait FileLoader {
+    /// Read a module's source text. `path` is already canonical.
+    ///
+    /// # Errors
+    /// A human-readable message; it is rendered verbatim into the
+    /// `could not read …` import diagnostic.
+    fn read_to_string(&self, path: &Path) -> Result<String, String>;
+}
+
+/// [`FileLoader`] backed by the real filesystem.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct DiskLoader;
+
+impl FileLoader for DiskLoader {
+    fn read_to_string(&self, path: &Path) -> Result<String, String> {
+        fs::read_to_string(path).map_err(|e| e.to_string())
+    }
+}
+
+/// Best-effort outcome of [`resolve_with_loader`].
+///
+/// Carries the graph built so far *together with* every error
+/// encountered, instead of one or the other. `graph.modules` is empty
+/// only when a module cycle prevents topological ordering.
+#[derive(Debug)]
+pub struct Resolution {
+    pub graph: ModuleGraph,
+    pub errors: Vec<ResolveError>,
+    /// Source text of every loaded module, for diagnostic rendering.
+    pub sources: HashMap<ModuleId, String>,
+}
+
 /// Load + parse + check every supplied root and their transitive
 /// dependencies into a single graph.
 ///
@@ -142,7 +183,26 @@ pub struct EntrySource {
 /// type-check errors all funnel through the same shape — plus a
 /// `sources` map suitable for ariadne-style rendering.
 pub fn resolve(roots: Vec<EntrySource>) -> Result<ModuleGraph, ResolveErrors> {
-    let mut state = ResolveState::default();
+    let resolution = resolve_with_loader(roots, &DiskLoader);
+    if resolution.errors.is_empty() {
+        Ok(resolution.graph)
+    } else {
+        Err(ResolveErrors {
+            errors: resolution.errors,
+            sources: resolution.sources,
+        })
+    }
+}
+
+/// Like [`resolve`], but with pluggable file reading and a partial result.
+///
+/// Reads imported files through `loader` and always returns the graph
+/// built so far alongside the errors — the shape editor tooling needs
+/// to keep serving hover/completion for the modules that *did* check
+/// while diagnostics report the ones that didn't.
+#[must_use]
+pub fn resolve_with_loader(roots: Vec<EntrySource>, loader: &dyn FileLoader) -> Resolution {
+    let mut state = ResolveState::new(loader);
     let mut entries: Vec<ModuleId> = Vec::with_capacity(roots.len());
     let mut seen: HashSet<ModuleId> = HashSet::new();
     for root in roots {
@@ -154,8 +214,24 @@ pub fn resolve(roots: Vec<EntrySource>) -> Result<ModuleGraph, ResolveErrors> {
     state.into_graph(entries)
 }
 
-#[derive(Default)]
-struct ResolveState {
+/// Everything in scope for `module`: stdlib builtins plus its resolved
+/// imports. This is the exact symbol set the checker ran with; editor
+/// tooling uses it for hover and completion.
+#[must_use]
+pub fn imported_symbols(module: &CheckedModule, graph: &ModuleGraph) -> ImportedSymbols {
+    build_imported_symbols(&module.imports, &graph.modules)
+}
+
+/// The implicit stdlib scope on its own — what a module sees before
+/// any `use` import resolves. Editor fallback for buffers that have no
+/// checked module yet.
+#[must_use]
+pub fn stdlib_symbols() -> ImportedSymbols {
+    build_imported_symbols(&HashMap::new(), &HashMap::new())
+}
+
+struct ResolveState<'a> {
+    loader: &'a dyn FileLoader,
     raw: HashMap<ModuleId, RawModule>,
     /// Queue of module IDs whose `use` items still need resolving.
     pending: Vec<ModuleId>,
@@ -169,7 +245,16 @@ struct RawModule {
     base_dir: PathBuf,
 }
 
-impl ResolveState {
+impl<'a> ResolveState<'a> {
+    fn new(loader: &'a dyn FileLoader) -> Self {
+        Self {
+            loader,
+            raw: HashMap::new(),
+            pending: Vec::new(),
+            errors: Vec::new(),
+        }
+    }
+
     fn load_module(&mut self, id: ModuleId, source: String, base_dir: &Path) {
         if self.raw.contains_key(&id) {
             return;
@@ -213,7 +298,7 @@ impl ResolveState {
                 if self.raw.contains_key(&id) {
                     return;
                 }
-                let text = match fs::read_to_string(&path) {
+                let text = match self.loader.read_to_string(&path) {
                     Ok(t) => t,
                     Err(e) => {
                         self.errors.push(ResolveError {
@@ -238,7 +323,7 @@ impl ResolveState {
         }
     }
 
-    fn into_graph(mut self, entries: Vec<ModuleId>) -> Result<ModuleGraph, ResolveErrors> {
+    fn into_graph(mut self, entries: Vec<ModuleId>) -> Resolution {
         // `raw` is drained below as modules become `CheckedModule`s,
         // so snapshot every loaded module's source up front for the
         // failure-path renderer.
@@ -264,10 +349,15 @@ impl ResolveState {
                         ),
                     )],
                 });
-                return Err(ResolveErrors {
+                return Resolution {
+                    graph: ModuleGraph {
+                        modules: HashMap::new(),
+                        entries,
+                        topo_order: Vec::new(),
+                    },
                     errors: self.errors,
                     sources,
-                });
+                };
             }
         };
 
@@ -318,17 +408,14 @@ impl ResolveState {
             );
         }
 
-        if self.errors.is_empty() {
-            Ok(ModuleGraph {
+        Resolution {
+            graph: ModuleGraph {
                 modules,
                 entries,
                 topo_order: topo,
-            })
-        } else {
-            Err(ResolveErrors {
-                errors: self.errors,
-                sources,
-            })
+            },
+            errors: self.errors,
+            sources,
         }
     }
 

--- a/crates/keron-modules/tests/resolver.rs
+++ b/crates/keron-modules/tests/resolver.rs
@@ -9,7 +9,11 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicUsize, Ordering};
 
-use keron_modules::{EntrySource, ModuleId, resolve};
+use std::collections::HashMap;
+
+use keron_modules::{
+    DiskLoader, EntrySource, FileLoader, ModuleId, imported_symbols, resolve, resolve_with_loader,
+};
 
 static COUNTER: AtomicUsize = AtomicUsize::new(0);
 
@@ -479,4 +483,124 @@ fn multi_root_loads_every_root_into_the_graph() {
     assert!(graph.modules.contains_key(&b_id), "b missing from modules");
     assert_eq!(graph.entries.len(), 2);
     assert!(graph.entries.contains(&a_id) && graph.entries.contains(&b_id));
+}
+
+/// [`FileLoader`] over an in-memory map, falling back to disk —
+/// the same shape an editor overlay uses for open buffers.
+struct OverlayLoader {
+    overlay: HashMap<PathBuf, String>,
+}
+
+impl FileLoader for OverlayLoader {
+    fn read_to_string(&self, path: &Path) -> Result<String, String> {
+        if let Some(text) = self.overlay.get(path) {
+            return Ok(text.clone());
+        }
+        DiskLoader.read_to_string(path)
+    }
+}
+
+#[test]
+fn loader_overlay_wins_over_disk_content() {
+    // Disk says lib.keron exports nothing; the overlay says it
+    // exports `greet`. The overlay must win: resolution succeeds.
+    let proj = TempProject::new("overlay-wins");
+    let lib_path = proj.write("lib.keron", "val unrelated: Int = 1\n");
+    let main_path = proj.write(
+        "main.keron",
+        "from \"./lib.keron\" use greet\nval g: String = greet()\n",
+    );
+    let main_src = fs::read_to_string(&main_path).unwrap();
+    let overlay = HashMap::from([(
+        fs::canonicalize(&lib_path).unwrap(),
+        "fn greet(): String { \"hi\" }\n".to_string(),
+    )]);
+    let resolution = resolve_with_loader(
+        TempProject::roots(&[(&main_path, &main_src)]),
+        &OverlayLoader { overlay },
+    );
+    assert!(
+        resolution.errors.is_empty(),
+        "overlay content should satisfy the import, got: {:?}",
+        resolution.errors,
+    );
+    let lib_id = ModuleId(fs::canonicalize(&lib_path).unwrap());
+    let lib = resolution.graph.modules.get(&lib_id).expect("lib in graph");
+    assert!(lib.exported_fns.contains("greet"));
+}
+
+#[test]
+fn loader_falls_back_to_disk_for_unopened_deps() {
+    let proj = TempProject::new("overlay-disk-fallback");
+    proj.write("lib.keron", "fn greet(): String { \"hi\" }\n");
+    let main_path = proj.write(
+        "main.keron",
+        "from \"./lib.keron\" use greet\nval g: String = greet()\n",
+    );
+    let main_src = fs::read_to_string(&main_path).unwrap();
+    let resolution = resolve_with_loader(
+        TempProject::roots(&[(&main_path, &main_src)]),
+        &OverlayLoader {
+            overlay: HashMap::new(),
+        },
+    );
+    assert!(
+        resolution.errors.is_empty(),
+        "disk fallback should satisfy the import, got: {:?}",
+        resolution.errors,
+    );
+}
+
+#[test]
+fn resolution_keeps_partial_graph_alongside_errors() {
+    // One healthy module, one with a type error. The failing module
+    // must produce an error AND both modules must still be present in
+    // the graph so editor features keep working.
+    let proj = TempProject::new("partial-graph");
+    let good_path = proj.write("good.keron", "fn greet(): String { \"hi\" }\n");
+    let bad_path = proj.write("bad.keron", "val n: Int = \"not an int\"\n");
+    let good_src = fs::read_to_string(&good_path).unwrap();
+    let bad_src = fs::read_to_string(&bad_path).unwrap();
+    let resolution = resolve_with_loader(
+        TempProject::roots(&[(&good_path, &good_src), (&bad_path, &bad_src)]),
+        &DiskLoader,
+    );
+    let bad_id = ModuleId(fs::canonicalize(&bad_path).unwrap());
+    let good_id = ModuleId(fs::canonicalize(&good_path).unwrap());
+    assert!(
+        resolution.errors.iter().any(|e| e.module == bad_id),
+        "expected an error for bad.keron, got: {:?}",
+        resolution.errors,
+    );
+    assert!(
+        resolution.graph.modules.contains_key(&good_id),
+        "good module must survive in the partial graph",
+    );
+    assert!(
+        resolution.graph.modules.contains_key(&bad_id),
+        "failing module still parses, so it must stay in the graph",
+    );
+    assert!(resolution.sources.contains_key(&bad_id));
+}
+
+#[test]
+fn imported_symbols_exposes_builtins_and_imports() {
+    let proj = TempProject::new("imported-symbols");
+    proj.write("lib.keron", "fn greet(): String { \"hi\" }\n");
+    let main_path = proj.write(
+        "main.keron",
+        "from \"./lib.keron\" use greet\nval g: String = greet()\n",
+    );
+    let main_src = fs::read_to_string(&main_path).unwrap();
+    let resolution =
+        resolve_with_loader(TempProject::roots(&[(&main_path, &main_src)]), &DiskLoader);
+    assert!(resolution.errors.is_empty(), "{:?}", resolution.errors);
+    let main_id = ModuleId(fs::canonicalize(&main_path).unwrap());
+    let module = resolution.graph.modules.get(&main_id).expect("main module");
+    let symbols = imported_symbols(module, &resolution.graph);
+    assert!(symbols.fns.contains_key("greet"), "import must be in scope");
+    assert!(
+        symbols.builtins.contains("symlink"),
+        "stdlib builtins must be seeded",
+    );
 }

--- a/docs/editors.md
+++ b/docs/editors.md
@@ -1,0 +1,96 @@
+# Editor integration
+
+keron ships a Language Server: `keron lsp` speaks LSP over stdio and
+provides diagnostics as you type, hover signatures, completion,
+go-to-definition (including across `use` imports), whole-document
+formatting (the same engine as `keron format`), outline symbols,
+signature help, and semantic-token syntax highlighting.
+
+Any editor with an LSP client can use it — configure the editor to run
+`keron lsp` for `.keron` files. The `keron` binary must be installed
+and on `PATH`.
+
+Semantic-token highlighting renders in editors that support it
+(VS Code, Neovim). Helix and Zed highlight via tree-sitter only, so
+`.keron` files stay uncolored there for now; every other feature works.
+
+## Neovim (0.11+)
+
+```lua
+vim.filetype.add({ extension = { keron = "keron" } })
+
+vim.lsp.config("keron", {
+  cmd = { "keron", "lsp" },
+  filetypes = { "keron" },
+  root_markers = { ".git" },
+})
+vim.lsp.enable("keron")
+```
+
+Older Neovim (0.9/0.10) can start it manually:
+
+```lua
+vim.filetype.add({ extension = { keron = "keron" } })
+vim.api.nvim_create_autocmd("FileType", {
+  pattern = "keron",
+  callback = function()
+    vim.lsp.start({ name = "keron", cmd = { "keron", "lsp" } })
+  end,
+})
+```
+
+## Helix
+
+`~/.config/helix/languages.toml`:
+
+```toml
+[language-server.keron]
+command = "keron"
+args = ["lsp"]
+
+[[language]]
+name = "keron"
+scope = "source.keron"
+file-types = ["keron"]
+comment-token = "#"
+language-servers = ["keron"]
+```
+
+## VS Code
+
+Install the bundled extension from `editors/vscode` (not on the
+marketplace yet):
+
+```sh
+cd editors/vscode
+npm install
+npm run compile
+npx @vscode/vsce package
+code --install-extension keron-*.vsix
+```
+
+Point `keron.serverPath` at the binary if it is not on VS Code's
+`PATH`.
+
+## Zed
+
+Install the bundled dev extension from `editors/zed` (not in the Zed
+registry yet): run the `zed: install dev extension` action and pick
+the `editors/zed` directory. Zed compiles it to WebAssembly itself.
+
+## Emacs (eglot)
+
+```elisp
+;; assuming a keron-mode bound to .keron files
+(add-to-list 'eglot-server-programs '(keron-mode "keron" "lsp"))
+```
+
+## Kakoune (kakoune-lsp)
+
+```toml
+[language_server.keron]
+filetypes = ["keron"]
+roots = [".git"]
+command = "keron"
+args = ["lsp"]
+```

--- a/editors/vscode/.gitignore
+++ b/editors/vscode/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+out/
+*.vsix

--- a/editors/vscode/.vscodeignore
+++ b/editors/vscode/.vscodeignore
@@ -1,0 +1,5 @@
+src/**
+tsconfig.json
+node_modules/@types/**
+**/*.map
+.gitignore

--- a/editors/vscode/README.md
+++ b/editors/vscode/README.md
@@ -1,0 +1,32 @@
+# keron for VS Code
+
+Language support for [keron](https://github.com/icepuma/keron):
+diagnostics as you type, hover signatures, completion,
+go-to-definition (including across `use` imports), document formatting
+(`keron format`), outline symbols, signature help, and semantic-token
+syntax highlighting.
+
+The extension is a thin client — it spawns `keron lsp` and everything
+else happens in the keron binary.
+
+## Requirements
+
+The `keron` binary must be installed and on your `PATH` (or point
+`keron.serverPath` at it in the settings).
+
+## Install (sideload)
+
+The extension is not on the marketplace yet. Build and install a vsix:
+
+```sh
+cd editors/vscode
+npm install
+npm run compile
+npx @vscode/vsce package
+code --install-extension keron-*.vsix
+```
+
+## Settings
+
+- `keron.serverPath` — path to the `keron` binary (default: `keron`
+  from `PATH`). The extension runs `<serverPath> lsp`.

--- a/editors/vscode/language-configuration.json
+++ b/editors/vscode/language-configuration.json
@@ -1,0 +1,22 @@
+{
+  "comments": {
+    "lineComment": "#"
+  },
+  "brackets": [
+    ["{", "}"],
+    ["[", "]"],
+    ["(", ")"]
+  ],
+  "autoClosingPairs": [
+    { "open": "{", "close": "}" },
+    { "open": "[", "close": "]" },
+    { "open": "(", "close": ")" },
+    { "open": "\"", "close": "\"", "notIn": ["string"] }
+  ],
+  "surroundingPairs": [
+    ["{", "}"],
+    ["[", "]"],
+    ["(", ")"],
+    ["\"", "\""]
+  ]
+}

--- a/editors/vscode/package-lock.json
+++ b/editors/vscode/package-lock.json
@@ -1,0 +1,156 @@
+{
+  "name": "keron",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "keron",
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "vscode-languageclient": "^10.1.0"
+      },
+      "devDependencies": {
+        "@types/node": "^20.0.0",
+        "@types/vscode": "^1.90.0",
+        "typescript": "^5.5.0"
+      },
+      "engines": {
+        "vscode": "^1.90.0"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.43",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.43.tgz",
+      "integrity": "sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/vscode": {
+      "version": "1.125.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.125.0.tgz",
+      "integrity": "sha512-0icm/ZQAaism87P0ekHqi4/Ju9du+Tm0RUW+y7vqRsxY2cY0FNRX1nAnaW7nT6npPt2tfHiheZ55Zm9UhqonFA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vscode-jsonrpc": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-9.0.1.tgz",
+      "integrity": "sha512-rfuA6T75H6m5EkbhtEPzre9pT0HPcDI2MMy4+nPFIBks5J8JBAUHD4tRYSgaBOijIEC7SRkC1kKyXTLqbmh9jw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/vscode-languageclient": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-10.1.0.tgz",
+      "integrity": "sha512-XXRx6lqVitQy/oOLr9MfNYRG+MbQkhXkDaxbQMiKxEm8zZNfheRFUKNb8UYNh2stn9btl2wQM5wZFJjJvoc+jA==",
+      "license": "MIT",
+      "dependencies": {
+        "minimatch": "^10.2.5",
+        "semver": "^7.8.1",
+        "vscode-languageserver-protocol": "3.18.2",
+        "vscode-languageserver-textdocument": "1.0.13"
+      },
+      "engines": {
+        "vscode": "^1.91.0"
+      }
+    },
+    "node_modules/vscode-languageserver-protocol": {
+      "version": "3.18.2",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.18.2.tgz",
+      "integrity": "sha512-XRyDbT0Pp3sSNti3JmxVEUMySWCSi1hhM+/KUlCy1hV1zmrqpM1OwO12EAki8blhmLuIMpaJrYbo0OzGVfK2Qg==",
+      "license": "MIT",
+      "dependencies": {
+        "vscode-jsonrpc": "9.0.1",
+        "vscode-languageserver-types": "3.18.0"
+      }
+    },
+    "node_modules/vscode-languageserver-textdocument": {
+      "version": "1.0.13",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.13.tgz",
+      "integrity": "sha512-nx0ZHwMGIsVkzFG3/VLeJYBLTaFBRuNdGDvevvjuoayU5EOS2fEYazOhtCM3PI9ClMMg5igc0uwXtAq4tJj+Dw==",
+      "license": "MIT"
+    },
+    "node_modules/vscode-languageserver-types": {
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.18.0.tgz",
+      "integrity": "sha512-8TsGPNMIMiiBdkORgRSvLjuiEIiAFtO+KssmYWxQ+uSVvlf7RjK8YKCOjPzZ+YA04jXEV7+7LvkSmHkhpNS99g==",
+      "license": "MIT"
+    }
+  }
+}

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -1,0 +1,60 @@
+{
+  "name": "keron",
+  "displayName": "keron",
+  "description": "Language support for keron — diagnostics, hover, completion, go-to-definition, formatting, and semantic highlighting via `keron lsp`.",
+  "version": "0.1.0",
+  "publisher": "icepuma",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/icepuma/keron"
+  },
+  "engines": {
+    "vscode": "^1.90.0"
+  },
+  "categories": [
+    "Programming Languages",
+    "Linters",
+    "Formatters"
+  ],
+  "activationEvents": [],
+  "main": "./out/extension.js",
+  "contributes": {
+    "languages": [
+      {
+        "id": "keron",
+        "aliases": [
+          "keron"
+        ],
+        "extensions": [
+          ".keron"
+        ],
+        "configuration": "./language-configuration.json"
+      }
+    ],
+    "configuration": {
+      "title": "keron",
+      "properties": {
+        "keron.serverPath": {
+          "type": "string",
+          "default": "keron",
+          "description": "Path to the `keron` binary. The extension runs `<serverPath> lsp`."
+        }
+      }
+    }
+  },
+  "scripts": {
+    "compile": "tsc -p ./",
+    "watch": "tsc -watch -p ./",
+    "vscode:prepublish": "npm run compile",
+    "package": "vsce package"
+  },
+  "dependencies": {
+    "vscode-languageclient": "^10.1.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "@types/vscode": "^1.90.0",
+    "typescript": "^5.5.0"
+  }
+}

--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -1,0 +1,34 @@
+// VS Code client for the keron language server. All language smarts
+// live in `keron lsp` (the Rust binary); this extension only spawns it
+// and wires the LSP channel. Syntax highlighting comes from the
+// server's semantic tokens, so no TextMate grammar is bundled.
+
+import * as vscode from "vscode";
+import {
+  LanguageClient,
+  LanguageClientOptions,
+  ServerOptions,
+} from "vscode-languageclient/node";
+
+let client: LanguageClient | undefined;
+
+export async function activate(): Promise<void> {
+  const command =
+    vscode.workspace.getConfiguration("keron").get<string>("serverPath") ??
+    "keron";
+  const serverOptions: ServerOptions = { command, args: ["lsp"] };
+  const clientOptions: LanguageClientOptions = {
+    documentSelector: [{ scheme: "file", language: "keron" }],
+  };
+  client = new LanguageClient(
+    "keron",
+    "keron language server",
+    serverOptions,
+    clientOptions,
+  );
+  await client.start();
+}
+
+export function deactivate(): Thenable<void> | undefined {
+  return client?.stop();
+}

--- a/editors/vscode/tsconfig.json
+++ b/editors/vscode/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "module": "node16",
+    "moduleResolution": "node16",
+    "target": "ES2022",
+    "lib": ["ES2022"],
+    "outDir": "out",
+    "rootDir": "src",
+    "strict": true,
+    "sourceMap": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"]
+}

--- a/editors/zed/.gitignore
+++ b/editors/zed/.gitignore
@@ -1,0 +1,3 @@
+target/
+Cargo.lock
+*.wasm

--- a/editors/zed/Cargo.toml
+++ b/editors/zed/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "keron-zed"
+version = "0.1.0"
+edition = "2021"
+publish = false
+license = "MIT"
+
+[lib]
+path = "src/lib.rs"
+crate-type = ["cdylib"]
+
+[dependencies]
+zed_extension_api = "=0.7.0"

--- a/editors/zed/README.md
+++ b/editors/zed/README.md
@@ -1,0 +1,31 @@
+# keron for Zed
+
+Registers the keron language in [Zed](https://zed.dev) and connects it
+to `keron lsp`: diagnostics, hover, completion, go-to-definition,
+formatting, outline symbols, and signature help.
+
+Note: Zed highlights via tree-sitter grammars and does not render LSP
+semantic tokens, so `.keron` files stay uncolored until keron grows a
+tree-sitter grammar. Every other language feature works.
+
+## Requirements
+
+The `keron` binary must be on your `PATH`.
+
+## Install (dev extension)
+
+The extension is not in the Zed registry yet. Install it locally:
+
+1. Open Zed.
+2. Run the `zed: install dev extension` action (command palette).
+3. Pick this directory (`editors/zed`).
+
+Zed compiles the extension to WebAssembly itself (it will fetch the
+`wasm32-wasip1` toolchain if needed) and starts `keron lsp` the next
+time you open a `.keron` file.
+
+## Files
+
+- `extension.toml` — extension + language-server registration.
+- `languages/keron/config.toml` — the keron language definition.
+- `src/lib.rs` — spawns `keron lsp` from PATH.

--- a/editors/zed/extension.toml
+++ b/editors/zed/extension.toml
@@ -1,0 +1,11 @@
+id = "keron"
+name = "keron"
+description = "keron language support (diagnostics, hover, completion, formatting via keron lsp)"
+version = "0.1.0"
+schema_version = 1
+authors = ["Stefan Ruzitschka <stefan@icepuma.dev>"]
+repository = "https://github.com/icepuma/keron"
+
+[language_servers.keron-lsp]
+name = "keron LSP"
+languages = ["keron"]

--- a/editors/zed/languages/keron/config.toml
+++ b/editors/zed/languages/keron/config.toml
@@ -1,0 +1,15 @@
+# Language registration only — keron has no tree-sitter grammar yet,
+# so Zed shows plain text (Zed does not render LSP semantic tokens).
+# All LSP features (diagnostics, hover, completion, go-to-definition,
+# formatting) work through `keron lsp`.
+name = "keron"
+code_fence_block_name = "keron"
+path_suffixes = ["keron"]
+line_comments = ["# "]
+autoclose_before = ")]}"
+brackets = [
+    { start = "{", end = "}", close = true, newline = true },
+    { start = "[", end = "]", close = true, newline = true },
+    { start = "(", end = ")", close = true, newline = false },
+    { start = "\"", end = "\"", close = true, newline = false, not_in = ["string"] },
+]

--- a/editors/zed/src/lib.rs
+++ b/editors/zed/src/lib.rs
@@ -1,0 +1,30 @@
+//! Zed extension for keron: registers the `.keron` language and
+//! spawns `keron lsp` from the user's PATH as its language server.
+//! Compiled by Zed to wasm32-wasip1; not part of the keron workspace.
+
+use zed_extension_api::{self as zed, Result};
+
+struct KeronExtension;
+
+impl zed::Extension for KeronExtension {
+    fn new() -> Self {
+        Self
+    }
+
+    fn language_server_command(
+        &mut self,
+        _language_server_id: &zed::LanguageServerId,
+        worktree: &zed::Worktree,
+    ) -> Result<zed::Command> {
+        let command = worktree.which("keron").ok_or_else(|| {
+            "`keron` was not found on PATH; install keron and restart Zed".to_string()
+        })?;
+        Ok(zed::Command {
+            command,
+            args: vec!["lsp".to_string()],
+            env: Vec::new(),
+        })
+    }
+}
+
+zed::register_extension!(KeronExtension);


### PR DESCRIPTION
## What

A built-in Language Server so any editor can hook into keron: `keron lsp` speaks LSP over stdio.

**Features**: live diagnostics (parse + import resolution + type check, with `note:`/`help:` appended), hover signatures, completion (builtins with real signatures, locals, imports, keywords), go-to-definition (including cross-file through `from … use …`), whole-document formatting (same engine as `keron format`), outline symbols, signature help with named-argument mapping, and semantic-token syntax highlighting.

## How

- **`keron-modules`**: new `FileLoader` trait + `resolve_with_loader` returning a `Resolution` (partial graph **and** errors together) so open editor buffers overlay disk reads and healthy modules keep serving features while one file is broken. `resolve()` is an unchanged wrapper. New public `imported_symbols`/`stdlib_symbols`.
- **`keron-lang`**: new `tokens.rs`, an error-tolerant lexical scanner that never fails (handles all three string forms and tokenizes inside `${…}` interpolations) — highlighting works on half-typed buffers.
- **`crates/keron-lsp`** (new): `lsp-server = 0.8.0` + `lsp-types = 0.97.0` (rust-analyzer's sync stack — no tokio). Full-text sync, synchronous whole-workspace re-resolve per change, publish-delta diagnostics, and a *last-good snapshot* strategy: mid-edit unparseable buffers keep answering hover/completion from the last parseable version while diagnostics track the live text. Hand-rolled `file://` ⇄ path conversion (lsp-types 0.97 dropped the helpers) incl. Windows drive letters and `\\?\` verbatim prefixes; UTF-16 positions via a proptest-covered line index.
- **`keron-cli`**: new `Lsp` subcommand.
- **`editors/vscode`**: thin TS client (compiles + packages to vsix). **`editors/zed`**: wasm extension (workspace-excluded), verified `wasm32-wasip1` build.
- **`docs/editors.md`**: Neovim / Helix / VS Code / Zed / Emacs / Kakoune setup.

## Verification

- 1711 tests green via `just` (67 new: proptest roundtrips for line index + URI, node-at-offset and scope-resolution fixtures, scanner tests, resolver overlay/partial-graph tests, and 6 in-memory end-to-end LSP scenarios).
- Drove the real compiled binary over raw stdio JSON-RPC: handshake, diagnostics, hover, semantic tokens, clean exit (caught and fixed an exit-hang: the connection must drop before joining lsp-server's IO threads).

## Follow-ups (out of scope)

Chumsky error recovery in the grammar (accurate in-edit features), builtin doc table for rich hover, tree-sitter grammar (Helix/Zed highlighting), struct-field-aware completion, marketplace/registry publishing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)