### PR TITLE
feat: LSP feature completion — references, rename, quickfixes, inlay hints, navigation

### DIFF
--- a/crates/keron-lang/src/check/mod.rs
+++ b/crates/keron-lang/src/check/mod.rs
@@ -546,6 +546,11 @@ pub struct CheckOutput {
     /// the table, an Int inhabiting a static `Double` (e.g. from
     /// `[1, 2.5]`) would silently take the integer-division path.
     pub double_promotions: HashSet<(usize, usize)>,
+    /// Inferred type of every *unannotated* top-level `val`, keyed by
+    /// the `(start, end)` byte span of its name. Editor tooling reads
+    /// this for inlay hints and hover; annotated vals are absent
+    /// (their annotation is already in the source).
+    pub val_types: HashMap<(usize, usize), Type>,
 }
 
 /// [`check_module`] plus the [`CheckOutput`] byproducts. Split so the
@@ -650,10 +655,28 @@ pub fn check_module_full(
             .iter()
             .map(|span| (span.start, span.end))
             .collect();
-        Ok(CheckOutput { double_promotions })
+        Ok(CheckOutput {
+            double_promotions,
+            val_types: collect_val_types(program, &val_env),
+        })
     } else {
         Err(diags)
     }
+}
+
+/// Inferred types of unannotated top-level vals, keyed by name span —
+/// see [`CheckOutput::val_types`].
+fn collect_val_types(program: &Program, val_env: &Env) -> HashMap<(usize, usize), Type> {
+    program
+        .items
+        .iter()
+        .filter_map(|item| match item {
+            Item::Val(v) if v.ty.is_none() => val_env
+                .lookup(&v.name.node)
+                .map(|t| ((v.name.span.start, v.name.span.end), t.clone())),
+            _ => None,
+        })
+        .collect()
 }
 
 fn redefine_diagnostic(span: Span, name: &str, imported: &ImportedSymbols) -> Diagnostic {

--- a/crates/keron-lsp/src/analysis/mod.rs
+++ b/crates/keron-lsp/src/analysis/mod.rs
@@ -3,6 +3,7 @@
 //! per-module errors into `publishDiagnostics` payloads.
 
 pub mod node_at;
+pub mod refs;
 pub mod symbols;
 
 use std::collections::HashMap;

--- a/crates/keron-lsp/src/analysis/refs.rs
+++ b/crates/keron-lsp/src/analysis/refs.rs
@@ -1,0 +1,414 @@
+//! Reference collection — the shared engine behind find-references,
+//! rename, and document highlight.
+//!
+//! keron has one flat top-level namespace per module (the checker
+//! rejects a `val` and a `fn` sharing a name), so a name maps to at
+//! most one top-level declaration. The only shadowing is value-scoped:
+//! params, `for` bindings, block vals, and match binds can shadow an
+//! outer val. Accordingly, value references are verified through
+//! [`find_local_def`] (does this occurrence resolve to the same
+//! definition site?) while callee/type/use references match by name.
+
+use keron_lang::{
+    Block, Expr, ForPattern, Item, Pattern, Program, Span, Spanned, Stmt, StringPart,
+};
+
+use crate::analysis::symbols::find_local_def;
+
+/// How a name occurrence participates in the program — this decides
+/// both whether it belongs to a given rename and how the edit is
+/// spelled.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HitKind {
+    /// The defining name of a decl / param / binding.
+    Decl,
+    /// A value reference (`Expr::Var`).
+    VarRef,
+    /// A callee or struct-literal name.
+    CalleeRef,
+    /// A name inside a type annotation (span already refined to the
+    /// exact identifier).
+    TypeRef,
+    /// A name in a `from "…" use …` list.
+    UseName,
+    /// Shorthand struct-literal field (`P { x }`) or shorthand
+    /// pattern field — the name is simultaneously the field and a
+    /// value binding/reference, so a rename must expand it to
+    /// `field: new_name` instead of replacing it.
+    Shorthand,
+}
+
+#[derive(Debug, Clone)]
+pub struct NameHit {
+    pub span: Span,
+    pub kind: HitKind,
+}
+
+/// Every occurrence of `name` in `program` (declarations, value refs,
+/// callees, type positions, use lists, shorthand fields). Field-name
+/// positions (struct field decls, `receiver.field`, named args,
+/// non-shorthand literal/pattern fields) are deliberately excluded —
+/// fields are a separate namespace.
+#[must_use]
+pub fn collect_name_hits(program: &Program, text: &str, name: &str) -> Vec<NameHit> {
+    let mut c = Collector {
+        name,
+        text,
+        hits: Vec::new(),
+    };
+    for item in &program.items {
+        c.item(item);
+    }
+    c.hits.sort_by_key(|h| h.span.start);
+    c.hits.dedup_by_key(|h| h.span.start);
+    c.hits
+}
+
+/// Spans of named arguments `param = …` in every call to `fn_name` —
+/// the extra edits a *param* rename needs.
+#[must_use]
+pub fn named_arg_spans(program: &Program, fn_name: &str, param: &str) -> Vec<Span> {
+    let mut spans = Vec::new();
+    crate::analysis::node_at::walk_exprs(program, &mut |e| {
+        if let Expr::Call { callee, args } = &e.node
+            && callee.node == fn_name
+        {
+            for arg in args {
+                if let Some(n) = &arg.name
+                    && n.node == param
+                {
+                    spans.push(n.span.clone());
+                }
+            }
+        }
+    });
+    spans
+}
+
+/// Does the value reference at `offset` resolve to the definition
+/// whose name occupies `def_span`? Used to drop shadowed occurrences.
+#[must_use]
+pub fn resolves_to(program: &Program, name: &str, offset: usize, def_span: &Span) -> bool {
+    find_local_def(program, name, offset).is_some_and(|d| d.name_span() == *def_span)
+}
+
+struct Collector<'a> {
+    name: &'a str,
+    text: &'a str,
+    hits: Vec<NameHit>,
+}
+
+impl Collector<'_> {
+    fn hit(&mut self, span: Span, kind: HitKind) {
+        self.hits.push(NameHit { span, kind });
+    }
+
+    fn named(&mut self, spanned: &Spanned<String>, kind: HitKind) {
+        if spanned.node == self.name {
+            self.hit(spanned.span.clone(), kind);
+        }
+    }
+
+    /// A `Spanned<Type>` covers the whole annotation (`List<Point>`),
+    /// so find the exact identifier occurrences textually. Type
+    /// annotations only contain type names and punctuation, making a
+    /// word-boundary scan exact.
+    fn ty(&mut self, span: &Span) {
+        let is_ident = |c: char| c.is_alphanumeric() || c == '_';
+        let hay = &self.text[span.start.min(self.text.len())..span.end.min(self.text.len())];
+        let mut from = 0;
+        while let Some(i) = hay[from..].find(self.name) {
+            let start = from + i;
+            let end = start + self.name.len();
+            let before_ok = start == 0 || !hay[..start].chars().next_back().is_some_and(is_ident);
+            let after_ok = !hay[end..].chars().next().is_some_and(is_ident);
+            if before_ok && after_ok {
+                self.hit(span.start + start..span.start + end, HitKind::TypeRef);
+            }
+            from = end;
+        }
+    }
+
+    fn item(&mut self, item: &Item) {
+        match item {
+            Item::Use(u) => {
+                for n in &u.names {
+                    self.named(n, HitKind::UseName);
+                }
+            }
+            Item::Val(v) => {
+                self.named(&v.name, HitKind::Decl);
+                if let Some(ty) = &v.ty {
+                    self.ty(&ty.span);
+                }
+                self.expr(&v.value);
+            }
+            Item::Fn(f) => {
+                self.named(&f.name, HitKind::Decl);
+                for p in &f.params {
+                    self.named(&p.name, HitKind::Decl);
+                    self.ty(&p.ty.span);
+                    if let Some(d) = &p.default {
+                        self.expr(d);
+                    }
+                }
+                self.ty(&f.return_type.span);
+                self.block(&f.body);
+            }
+            Item::Struct(s) => {
+                self.named(&s.name, HitKind::Decl);
+                for field in &s.fields {
+                    self.ty(&field.ty.span);
+                    if let Some(d) = &field.default {
+                        self.expr(d);
+                    }
+                }
+            }
+            Item::TypeAlias(t) => self.named(&t.name, HitKind::Decl),
+            Item::Reconcile(r) => {
+                for e in r.chains.iter().flatten() {
+                    self.expr(e);
+                }
+            }
+            Item::ExprStmt(e) => self.expr(e),
+        }
+    }
+
+    fn block(&mut self, b: &Block) {
+        for stmt in &b.stmts {
+            match stmt {
+                Stmt::Val(v) => {
+                    self.named(&v.name, HitKind::Decl);
+                    if let Some(ty) = &v.ty {
+                        self.ty(&ty.span);
+                    }
+                    self.expr(&v.value);
+                }
+                Stmt::Reconcile(r) => {
+                    for e in r.chains.iter().flatten() {
+                        self.expr(e);
+                    }
+                }
+                Stmt::Expr(e) => self.expr(e),
+            }
+        }
+        if let Some(t) = &b.trailing {
+            self.expr(t);
+        }
+    }
+
+    fn expr(&mut self, e: &Spanned<Expr>) {
+        match &e.node {
+            Expr::Var(n) => {
+                if n == self.name {
+                    self.hit(e.span.clone(), HitKind::VarRef);
+                }
+            }
+            Expr::Literal(_) => {}
+            Expr::Unary { operand, .. } => self.expr(operand),
+            Expr::Binary { lhs, rhs, .. } => {
+                self.expr(lhs);
+                self.expr(rhs);
+            }
+            Expr::Interpolation(parts) => {
+                for p in parts {
+                    if let StringPart::Expr { expr, .. } = p {
+                        self.expr(expr);
+                    }
+                }
+            }
+            Expr::List(items) => {
+                for x in items {
+                    self.expr(x);
+                }
+            }
+            Expr::Map(entries) => {
+                for en in entries {
+                    self.expr(&en.key);
+                    self.expr(&en.value);
+                }
+            }
+            Expr::Call { callee, args } => {
+                self.named(callee, HitKind::CalleeRef);
+                for a in args {
+                    self.expr(&a.value);
+                }
+            }
+            Expr::StructLiteral { name, fields } => {
+                self.named(name, HitKind::CalleeRef);
+                for f in fields {
+                    match &f.value {
+                        Some(v) => self.expr(v),
+                        None => self.named(&f.name, HitKind::Shorthand),
+                    }
+                }
+            }
+            Expr::If {
+                cond,
+                then_branch,
+                else_branch,
+            } => {
+                self.expr(cond);
+                self.block(then_branch);
+                self.block(else_branch);
+            }
+            Expr::For {
+                pattern,
+                iter_expr,
+                body,
+            } => {
+                match pattern {
+                    ForPattern::Elem(n) => self.named(n, HitKind::Decl),
+                    ForPattern::Entry { key, value } => {
+                        self.named(key, HitKind::Decl);
+                        self.named(value, HitKind::Decl);
+                    }
+                }
+                self.expr(iter_expr);
+                self.block(body);
+            }
+            Expr::Field { receiver, .. } => self.expr(receiver),
+            Expr::Match { scrutinee, arms } => {
+                self.expr(scrutinee);
+                for arm in arms {
+                    self.pattern(&arm.pattern);
+                    if let Some(g) = &arm.guard {
+                        self.expr(g);
+                    }
+                    self.expr(&arm.body);
+                }
+            }
+        }
+    }
+
+    fn pattern(&mut self, p: &Spanned<Pattern>) {
+        match &p.node {
+            Pattern::Bind(n) => {
+                if n == self.name {
+                    self.hit(p.span.clone(), HitKind::Decl);
+                }
+            }
+            Pattern::Struct { name, fields } => {
+                self.named(name, HitKind::CalleeRef);
+                for f in fields {
+                    match &f.pattern {
+                        Some(sub) => self.pattern(sub),
+                        None => self.named(&f.name, HitKind::Shorthand),
+                    }
+                }
+            }
+            Pattern::Lit(_) | Pattern::Wildcard => {}
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use keron_lang::parse;
+
+    fn hits(src: &str, name: &str) -> Vec<(HitKind, String)> {
+        let program = parse(src).expect("fixture parses");
+        collect_name_hits(&program, src, name)
+            .into_iter()
+            .map(|h| (h.kind, src[h.span].to_string()))
+            .collect()
+    }
+
+    #[test]
+    fn val_decl_and_refs_including_interpolation() {
+        let src = "val name: String = \"x\"\nval msg: String = \"hi ${name}\"\nval again: String = name\n";
+        let got = hits(src, "name");
+        assert_eq!(
+            got,
+            vec![
+                (HitKind::Decl, "name".to_string()),
+                (HitKind::VarRef, "name".to_string()),
+                (HitKind::VarRef, "name".to_string()),
+            ]
+        );
+    }
+
+    #[test]
+    fn struct_hits_cover_decl_literal_annotation_and_pattern() {
+        let src = "struct Point { x: Int }\n\
+                   val p: Point = Point { x: 1 }\n\
+                   fn f(q: List<Point>): Int { match p { Point { x } => x } }\n";
+        let got = hits(src, "Point");
+        let kinds: Vec<HitKind> = got.iter().map(|(k, _)| *k).collect();
+        assert_eq!(
+            kinds,
+            vec![
+                HitKind::Decl,
+                HitKind::TypeRef,
+                HitKind::CalleeRef,
+                HitKind::TypeRef,
+                HitKind::CalleeRef,
+            ],
+            "got: {got:?}"
+        );
+    }
+
+    #[test]
+    fn type_annotation_refinement_is_word_boundary_exact() {
+        let src =
+            "struct P { x: Int }\nstruct PP { y: Int }\nfn f(a: Map<PP, List<P>>): Int { 1 }\n";
+        let got = hits(src, "P");
+        // Decl + exactly one occurrence inside the Map annotation —
+        // the `PP` must not match.
+        assert_eq!(got.len(), 2, "got: {got:?}");
+        assert!(got.iter().all(|(_, s)| s == "P"));
+    }
+
+    #[test]
+    fn shorthand_literal_field_is_flagged() {
+        let src = "struct P { x: Int }\nval x: Int = 1\nval p: P = P { x }\n";
+        let got = hits(src, "x");
+        assert_eq!(
+            got.last().map(|(k, _)| *k),
+            Some(HitKind::Shorthand),
+            "got: {got:?}"
+        );
+    }
+
+    #[test]
+    fn field_positions_are_excluded() {
+        // `x` as struct field decl, named arg, and field access must
+        // NOT appear; only the val decl and its var ref do.
+        let src = "struct S { x: Int }\n\
+                   val x: Int = 1\n\
+                   val s: S = S { x: x }\n\
+                   val n: Int = s.x\n";
+        let got = hits(src, "x");
+        assert_eq!(
+            got,
+            vec![
+                (HitKind::Decl, "x".to_string()),
+                (HitKind::VarRef, "x".to_string()),
+            ]
+        );
+    }
+
+    #[test]
+    fn named_arg_spans_find_param_uses() {
+        let src = "fn f(count: Int): Int { count }\nval a: Int = f(count = 1)\nval b: Int = f(2)\n";
+        let program = parse(src).expect("parses");
+        let spans = named_arg_spans(&program, "f", "count");
+        assert_eq!(spans.len(), 1);
+        assert_eq!(&src[spans[0].clone()], "count");
+    }
+
+    #[test]
+    fn resolves_to_rejects_shadowed_occurrences() {
+        let src = "val x: Int = 1\nfn f(x: Int): Int { x }\nval y: Int = x\n";
+        let program = parse(src).expect("parses");
+        let top_val_span = src.find('x').unwrap()..src.find('x').unwrap() + 1;
+        let body_ref = src.find("{ x }").unwrap() + 2;
+        let tail_ref = src.rfind('x').unwrap();
+        assert!(
+            !resolves_to(&program, "x", body_ref, &top_val_span),
+            "param-shadowed ref must not resolve to the top-level val"
+        );
+        assert!(resolves_to(&program, "x", tail_ref, &top_val_span));
+    }
+}

--- a/crates/keron-lsp/src/handlers/code_action.rs
+++ b/crates/keron-lsp/src/handlers/code_action.rs
@@ -1,0 +1,73 @@
+//! `textDocument/codeAction` — quickfixes derived from the checker's
+//! own suggestions.
+//!
+//! keron diagnostics carry a rustc-style ``help: did you mean `X`?``
+//! line (appended to the message on the way out — see
+//! [`super::diagnostics`]). The client echoes the diagnostics for the
+//! requested range back in the params, so the fix is stateless: parse
+//! the suggestion out of the message and offer a text edit replacing
+//! the diagnostic's span with it.
+
+use lsp_types::{
+    CodeAction, CodeActionKind, CodeActionOrCommand, CodeActionParams, TextEdit, WorkspaceEdit,
+};
+
+use crate::state::ServerState;
+
+pub fn handle(state: &ServerState, params: &CodeActionParams) -> Vec<CodeActionOrCommand> {
+    let _ = state;
+    params
+        .context
+        .diagnostics
+        .iter()
+        .filter_map(|diag| {
+            let suggestion = extract_suggestion(&diag.message)?;
+            let edit = TextEdit {
+                range: diag.range,
+                new_text: suggestion.clone(),
+            };
+            // clippy's mutable-key-type fires on Uri's interior
+            // cell; the map is write-once here, never rehashed after
+            // mutation.
+            #[allow(clippy::mutable_key_type)]
+            let changes =
+                std::collections::HashMap::from([(params.text_document.uri.clone(), vec![edit])]);
+            Some(CodeActionOrCommand::CodeAction(CodeAction {
+                title: format!("Replace with `{suggestion}`"),
+                kind: Some(CodeActionKind::QUICKFIX),
+                diagnostics: Some(vec![diag.clone()]),
+                edit: Some(WorkspaceEdit {
+                    changes: Some(changes),
+                    ..Default::default()
+                }),
+                is_preferred: Some(true),
+                ..Default::default()
+            }))
+        })
+        .collect()
+}
+
+/// Pull `X` out of a ``did you mean `X`?`` suggestion anywhere in the
+/// diagnostic message.
+fn extract_suggestion(message: &str) -> Option<String> {
+    let idx = message.find("did you mean `")?;
+    let rest = &message[idx + "did you mean `".len()..];
+    let end = rest.find('`')?;
+    let suggestion = &rest[..end];
+    (!suggestion.is_empty()).then(|| suggestion.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn extracts_suggestion_from_help_line() {
+        assert_eq!(
+            extract_suggestion("unknown identifier `naem`\nhelp: did you mean `name`?"),
+            Some("name".to_string())
+        );
+        assert_eq!(extract_suggestion("plain error"), None);
+        assert_eq!(extract_suggestion("did you mean ``?"), None);
+    }
+}

--- a/crates/keron-lsp/src/handlers/completion.rs
+++ b/crates/keron-lsp/src/handlers/completion.rs
@@ -11,7 +11,7 @@ use std::fs;
 use keron_lang::{Item, Type};
 use lsp_types::{
     CompletionItem, CompletionItemKind, CompletionParams, CompletionResponse, Documentation,
-    MarkupContent, MarkupKind,
+    InsertTextFormat, MarkupContent, MarkupKind,
 };
 
 use crate::analysis::node_at::enclosing_struct_literal;
@@ -186,6 +186,10 @@ fn scope_completion(snap: &Snapshot<'_>) -> Vec<CompletionItem> {
                 kind: MarkupKind::Markdown,
                 value: doc.to_string(),
             }));
+        }
+        if snap.snippets && !sig.params.is_empty() {
+            ci.insert_text = Some(render::call_snippet(name, sig));
+            ci.insert_text_format = Some(InsertTextFormat::SNIPPET);
         }
         items.push(ci);
     }

--- a/crates/keron-lsp/src/handlers/document_highlight.rs
+++ b/crates/keron-lsp/src/handlers/document_highlight.rs
@@ -1,0 +1,54 @@
+//! `textDocument/documentHighlight` — same-document occurrences of
+//! the symbol under the cursor. Reuses the reference collector,
+//! scoped to the current document only.
+
+use lsp_types::{DocumentHighlight, DocumentHighlightKind, DocumentHighlightParams};
+
+use crate::analysis::node_at::{NodeRef, node_at};
+use crate::analysis::refs::{HitKind, collect_name_hits, resolves_to};
+use crate::analysis::symbols::find_local_def;
+use crate::handlers::snapshot_at;
+use crate::state::ServerState;
+
+pub fn handle(
+    state: &ServerState,
+    params: &DocumentHighlightParams,
+) -> Option<Vec<DocumentHighlight>> {
+    let pos = &params.text_document_position_params;
+    let snap = snapshot_at(state, &pos.text_document.uri)?;
+    let offset = snap.index.offset(snap.text, pos.position, snap.enc)?;
+    let name = match node_at(snap.program, offset)? {
+        NodeRef::Callee(n) => n.node.clone(),
+        NodeRef::Var { name, .. } | NodeRef::TypeName { name, .. } => name.to_string(),
+        NodeRef::UseName { name } => name.node.clone(),
+        NodeRef::FnName(f) => f.name.node.clone(),
+        NodeRef::ValName(v) => v.name.node.clone(),
+        NodeRef::StructName(s) => s.name.node.clone(),
+        NodeRef::TypeAliasName(t) => t.name.node.clone(),
+        NodeRef::ParamName(p) => p.name.node.clone(),
+        _ => return None,
+    };
+    // Value occurrences respect shadowing when the cursor's own
+    // occurrence resolves locally; builtins and imports fall back to
+    // plain name matching, which is exact for the unshadowed case.
+    let def_span = find_local_def(snap.program, &name, offset).map(|d| d.name_span());
+    let highlights = collect_name_hits(snap.program, snap.text, &name)
+        .into_iter()
+        .filter(|hit| match (&def_span, hit.kind) {
+            (Some(def), HitKind::VarRef | HitKind::Shorthand) => {
+                resolves_to(snap.program, &name, hit.span.start, def)
+            }
+            (Some(def), HitKind::Decl) => hit.span == *def,
+            _ => true,
+        })
+        .map(|hit| DocumentHighlight {
+            range: snap.index.range(snap.text, &hit.span, snap.enc),
+            kind: Some(if hit.kind == HitKind::Decl {
+                DocumentHighlightKind::WRITE
+            } else {
+                DocumentHighlightKind::READ
+            }),
+        })
+        .collect();
+    Some(highlights)
+}

--- a/crates/keron-lsp/src/handlers/folding_range.rs
+++ b/crates/keron-lsp/src/handlers/folding_range.rs
@@ -1,0 +1,98 @@
+//! `textDocument/foldingRange` — fold multi-line items, blocks inside
+//! expressions, multiline strings, and runs of consecutive comments.
+
+use keron_lang::{Expr, LexTokenKind, lex_tokens};
+use lsp_types::{FoldingRange, FoldingRangeKind, FoldingRangeParams};
+
+use crate::analysis::node_at::walk_exprs;
+use crate::handlers::snapshot_at;
+use crate::line_index::LineIndex;
+use crate::state::ServerState;
+
+pub fn handle(state: &ServerState, params: &FoldingRangeParams) -> Option<Vec<FoldingRange>> {
+    let snap = snapshot_at(state, &params.text_document.uri)?;
+    let mut ranges = Vec::new();
+    let push = |ranges: &mut Vec<FoldingRange>,
+                index: &LineIndex,
+                span: &keron_lang::Span,
+                kind: Option<FoldingRangeKind>| {
+        let start = index.position(snap.text, span.start, snap.enc);
+        let end = index.position(snap.text, span.end, snap.enc);
+        // Item spans include the trailing newline; a fold ending at
+        // column 0 really ends on the previous line.
+        let end_line = if end.character == 0 && end.line > start.line {
+            end.line - 1
+        } else {
+            end.line
+        };
+        if end_line > start.line {
+            ranges.push(FoldingRange {
+                start_line: start.line,
+                start_character: None,
+                end_line,
+                end_character: None,
+                kind,
+                collapsed_text: None,
+            });
+        }
+    };
+
+    for item in &snap.program.items {
+        push(&mut ranges, snap.index, &item.span(), None);
+    }
+    walk_exprs(snap.program, &mut |e| {
+        if matches!(
+            e.node,
+            Expr::If { .. } | Expr::For { .. } | Expr::Match { .. } | Expr::Map(_) | Expr::List(_)
+        ) {
+            push(&mut ranges, snap.index, &e.span, None);
+        }
+    });
+
+    // Multiline strings and comment runs come from the lexical layer.
+    let mut comment_run: Option<(u32, u32)> = None;
+    for token in lex_tokens(snap.text) {
+        match token.kind {
+            LexTokenKind::Str => {
+                push(&mut ranges, snap.index, &token.span, None);
+            }
+            LexTokenKind::Comment => {
+                let line = snap
+                    .index
+                    .position(snap.text, token.span.start, snap.enc)
+                    .line;
+                comment_run = match comment_run {
+                    Some((start, end)) if line == end + 1 => Some((start, line)),
+                    Some((start, end)) => {
+                        if end > start {
+                            ranges.push(comment_fold(start, end));
+                        }
+                        Some((line, line))
+                    }
+                    None => Some((line, line)),
+                };
+            }
+            _ => {}
+        }
+    }
+    if let Some((start, end)) = comment_run
+        && end > start
+    {
+        ranges.push(comment_fold(start, end));
+    }
+
+    ranges.sort_by_key(|r| (r.start_line, r.end_line));
+    ranges.dedup_by_key(|r| (r.start_line, r.end_line));
+    Some(ranges)
+}
+
+const fn comment_fold(start_line: u32, end_line: u32) -> FoldingRange {
+    FoldingRange {
+        start_line,
+        start_character: None,
+        end_line,
+        end_character: None,
+        kind: Some(FoldingRangeKind::Comment),
+        collapsed_text: None,
+    }
+}

--- a/crates/keron-lsp/src/handlers/hover.rs
+++ b/crates/keron-lsp/src/handlers/hover.rs
@@ -16,7 +16,10 @@ pub fn handle(state: &ServerState, params: &HoverParams) -> Option<Hover> {
     let offset = snap.index.offset(snap.text, pos.position, snap.enc)?;
     let node = node_at(snap.program, offset)?;
     let imported = snap.imported_symbols();
-    let (text, span) = describe(&node, snap.program, offset, &imported)?;
+    let (mut text, span) = describe(&node, snap.program, offset, &imported)?;
+    if let Some(inferred) = inferred_val_signature(&snap, &node, offset) {
+        text = inferred;
+    }
     let mut value = format!("```keron\n{text}\n```");
     // Builtins get their prose paragraph under the signature.
     // (Imported names can never be builtins — the resolver rejects
@@ -34,6 +37,32 @@ pub fn handle(state: &ServerState, params: &HoverParams) -> Option<Hover> {
         }),
         range: span.map(|s| snap.index.range(snap.text, &s, snap.enc)),
     })
+}
+
+/// Unannotated vals render as bare `val name` from the AST; when the
+/// checked module (built from this exact text) recorded an inferred
+/// type, upgrade the hover to `val name: T`.
+fn inferred_val_signature(
+    snap: &crate::handlers::Snapshot<'_>,
+    node: &NodeRef<'_>,
+    offset: usize,
+) -> Option<String> {
+    let decl = match node {
+        NodeRef::ValName(v) => *v,
+        NodeRef::Var { name, .. } => match find_local_def(snap.program, name, offset)? {
+            LocalDef::Val(v) => v,
+            _ => return None,
+        },
+        _ => return None,
+    };
+    if decl.ty.is_some() {
+        return None;
+    }
+    let module = snap.module().filter(|m| m.source == snap.text)?;
+    let ty = module
+        .val_types
+        .get(&(decl.name.span.start, decl.name.span.end))?;
+    Some(format!("val {}: {ty}", decl.name.node))
 }
 
 fn describe(

--- a/crates/keron-lsp/src/handlers/inlay_hint.rs
+++ b/crates/keron-lsp/src/handlers/inlay_hint.rs
@@ -1,0 +1,97 @@
+//! `textDocument/inlayHint` — inferred types on unannotated top-level
+//! `val`s (from the checker's `val_types` byproduct) and parameter
+//! names on positional call arguments.
+
+use keron_lang::Expr;
+use lsp_types::{InlayHint, InlayHintKind, InlayHintLabel, InlayHintParams, Position};
+
+use crate::analysis::node_at::walk_exprs;
+use crate::handlers::snapshot_at;
+use crate::state::ServerState;
+
+pub fn handle(state: &ServerState, params: &InlayHintParams) -> Option<Vec<InlayHint>> {
+    let snap = snapshot_at(state, &params.text_document.uri)?;
+    let range_start = snap.index.offset(snap.text, params.range.start, snap.enc)?;
+    let range_end = snap.index.offset(snap.text, params.range.end, snap.enc)?;
+    let in_range = |offset: usize| offset >= range_start && offset <= range_end;
+    let mut hints = Vec::new();
+
+    // Inferred val types come from the *checked* module, whose spans
+    // are valid only when it was built from the same text the
+    // snapshot holds (a mid-edit buffer has a partial parse and a
+    // failed check — no hints then, which is fine).
+    if let Some(module) = snap.module()
+        && module.source == snap.text
+    {
+        for (&(_, end), ty) in &module.val_types {
+            if !in_range(end) {
+                continue;
+            }
+            hints.push(hint(
+                snap.index.position(snap.text, end, snap.enc),
+                format!(": {ty}"),
+                InlayHintKind::TYPE,
+                false,
+            ));
+        }
+    }
+
+    // Parameter names for positional arguments, from signatures we
+    // can resolve without inference.
+    let imported = snap.imported_symbols();
+    walk_exprs(snap.program, &mut |e| {
+        let Expr::Call { callee, args } = &e.node else {
+            return;
+        };
+        let params_sig: Vec<String> =
+            crate::analysis::symbols::find_local_def(snap.program, &callee.node, callee.span.start)
+                .and_then(|def| match def {
+                    crate::analysis::symbols::LocalDef::Fn(f) => {
+                        Some(f.params.iter().map(|p| p.name.node.clone()).collect())
+                    }
+                    _ => None,
+                })
+                .or_else(|| {
+                    imported
+                        .fns
+                        .get(&callee.node)
+                        .map(|sig| sig.params.iter().map(|p| p.name.clone()).collect())
+                })
+                .unwrap_or_default();
+        for (i, arg) in args.iter().enumerate() {
+            if arg.name.is_some() || !in_range(arg.value.span.start) {
+                continue;
+            }
+            if let Some(param_name) = params_sig.get(i) {
+                hints.push(hint(
+                    snap.index
+                        .position(snap.text, arg.value.span.start, snap.enc),
+                    format!("{param_name} = "),
+                    InlayHintKind::PARAMETER,
+                    true,
+                ));
+            }
+        }
+    });
+
+    hints.sort_by_key(|h| (h.position.line, h.position.character));
+    Some(hints)
+}
+
+const fn hint(
+    position: Position,
+    label: String,
+    kind: InlayHintKind,
+    pad_right: bool,
+) -> InlayHint {
+    InlayHint {
+        position,
+        label: InlayHintLabel::String(label),
+        kind: Some(kind),
+        text_edits: None,
+        tooltip: None,
+        padding_left: Some(false),
+        padding_right: Some(pad_right),
+        data: None,
+    }
+}

--- a/crates/keron-lsp/src/handlers/mod.rs
+++ b/crates/keron-lsp/src/handlers/mod.rs
@@ -1,15 +1,22 @@
 //! Request/notification dispatch. Every handler is a pure function
 //! over [`ServerState`]; the main loop owns all channel IO.
 
+pub mod code_action;
 pub mod completion;
 pub mod definition;
 pub mod diagnostics;
+pub mod document_highlight;
 pub mod document_symbol;
+pub mod folding_range;
 pub mod formatting;
 pub mod hover;
+pub mod inlay_hint;
+pub mod references;
 pub mod render;
+pub mod selection_range;
 pub mod semantic_tokens;
 pub mod signature_help;
+pub mod workspace_symbol;
 
 use std::fs;
 use std::path::PathBuf;
@@ -22,8 +29,10 @@ use lsp_types::notification::{
     PublishDiagnostics,
 };
 use lsp_types::request::{
-    Completion, DocumentSymbolRequest, Formatting, GotoDefinition, HoverRequest, Request as _,
-    SemanticTokensFullRequest, SignatureHelpRequest,
+    CodeActionRequest, Completion, DocumentHighlightRequest, DocumentSymbolRequest,
+    FoldingRangeRequest, Formatting, GotoDefinition, HoverRequest, InlayHintRequest,
+    PrepareRenameRequest, References, Rename, Request as _, SelectionRangeRequest,
+    SemanticTokensFullRequest, SignatureHelpRequest, WorkspaceSymbolRequest,
 };
 use lsp_types::{
     DidChangeTextDocumentParams, DidCloseTextDocumentParams, DidOpenTextDocumentParams,
@@ -47,6 +56,8 @@ pub struct Snapshot<'s> {
     pub path: &'s PathBuf,
     pub resolution: Option<&'s Resolution>,
     pub enc: PositionEncoding,
+    /// Client renders `$1` snippet placeholders in completions.
+    pub snippets: bool,
 }
 
 impl Snapshot<'_> {
@@ -82,6 +93,7 @@ pub fn snapshot_at<'s>(state: &'s ServerState, uri: &Uri) -> Option<Snapshot<'s>
         path,
         resolution: state.resolution.as_ref(),
         enc: state.encoding,
+        snippets: state.snippet_support,
     })
 }
 
@@ -99,6 +111,29 @@ pub fn handle_request(state: &ServerState, req: Request) -> Response {
         Formatting::METHOD => respond(req.id, req.params, |p| formatting::handle(state, &p)),
         SemanticTokensFullRequest::METHOD => {
             respond(req.id, req.params, |p| semantic_tokens::handle(state, &p))
+        }
+        References::METHOD => respond(req.id, req.params, |p| {
+            references::handle_references(state, &p)
+        }),
+        Rename::METHOD => respond(req.id, req.params, |p| references::handle_rename(state, &p)),
+        PrepareRenameRequest::METHOD => respond(req.id, req.params, |p| {
+            references::handle_prepare_rename(state, &p)
+        }),
+        DocumentHighlightRequest::METHOD => respond(req.id, req.params, |p| {
+            document_highlight::handle(state, &p)
+        }),
+        CodeActionRequest::METHOD => {
+            respond(req.id, req.params, |p| Some(code_action::handle(state, &p)))
+        }
+        InlayHintRequest::METHOD => respond(req.id, req.params, |p| inlay_hint::handle(state, &p)),
+        WorkspaceSymbolRequest::METHOD => {
+            respond(req.id, req.params, |p| workspace_symbol::handle(state, &p))
+        }
+        FoldingRangeRequest::METHOD => {
+            respond(req.id, req.params, |p| folding_range::handle(state, &p))
+        }
+        SelectionRangeRequest::METHOD => {
+            respond(req.id, req.params, |p| selection_range::handle(state, &p))
         }
         _ => Response::new_err(
             req.id,

--- a/crates/keron-lsp/src/handlers/references.rs
+++ b/crates/keron-lsp/src/handlers/references.rs
@@ -1,0 +1,364 @@
+//! `textDocument/references`, `textDocument/rename` (+prepare), built
+//! on the [`crate::analysis::refs`] collector.
+//!
+//! Cross-file references flow through the module graph: a top-level
+//! definition is visible in exactly the modules that `use`-import it
+//! (aliasing doesn't exist, so the imported name equals the declared
+//! name). Params and local bindings never leave their module.
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+use keron_lang::{Item, Program, Span};
+use lsp_types::{
+    Location, PrepareRenameResponse, ReferenceParams, RenameParams, TextDocumentPositionParams,
+    TextEdit, Uri, WorkspaceEdit,
+};
+
+use crate::analysis::node_at::{NodeRef, node_at};
+use crate::analysis::refs::{HitKind, NameHit, collect_name_hits, named_arg_spans, resolves_to};
+use crate::analysis::symbols::{LocalDef, find_local_def, top_level_decl_span};
+use crate::handlers::{Snapshot, snapshot_at};
+use crate::line_index::LineIndex;
+use crate::state::ServerState;
+use crate::uri::path_to_uri;
+
+/// Everything reserved: parser keywords (incl. the primitive type
+/// names) — a rename target/new-name may not collide with these.
+const RESERVED: &[&str] = &[
+    "val",
+    "fn",
+    "reconcile",
+    "if",
+    "else",
+    "for",
+    "in",
+    "match",
+    "struct",
+    "type",
+    "true",
+    "false",
+    "null",
+    "String",
+    "Int",
+    "Boolean",
+    "Double",
+    "List",
+    "Map",
+    "Void",
+];
+
+/// The definition a references/rename request targets.
+struct Target {
+    name: String,
+    /// Canonical path of the module holding the definition.
+    home: PathBuf,
+    /// Span of the defining name within the home module's text.
+    def_span: Span,
+    /// Params / local bindings never cross module boundaries.
+    local_only: bool,
+    /// `Some(fn_name)` when the target is a parameter — named
+    /// arguments at call sites reference it too.
+    param_of: Option<String>,
+}
+
+pub fn handle_references(state: &ServerState, params: &ReferenceParams) -> Option<Vec<Location>> {
+    let pos = &params.text_document_position;
+    let snap = snapshot_at(state, &pos.text_document.uri)?;
+    let target = resolve_target(&snap, pos)?;
+    let include_decl = params.context.include_declaration;
+    let mut locations = Vec::new();
+    for (uri, text, index, hits) in gather(state, &snap, &target) {
+        for hit in hits {
+            if hit.kind == HitKind::Decl && !include_decl {
+                continue;
+            }
+            locations.push(Location {
+                uri: uri.clone(),
+                range: index.range(&text, &hit.span, snap.enc),
+            });
+        }
+    }
+    Some(locations)
+}
+
+pub fn handle_prepare_rename(
+    state: &ServerState,
+    params: &TextDocumentPositionParams,
+) -> Option<PrepareRenameResponse> {
+    let snap = snapshot_at(state, &params.text_document.uri)?;
+    let target = resolve_target(&snap, params)?;
+    // Highlight the name under the cursor, not the (possibly
+    // cross-file) definition.
+    let offset = snap.index.offset(snap.text, params.position, snap.enc)?;
+    let span = match node_at(snap.program, offset)? {
+        NodeRef::Callee(n) => n.span.clone(),
+        NodeRef::Var { span, .. } | NodeRef::TypeName { span, .. } => span,
+        NodeRef::FnName(f) => f.name.span.clone(),
+        NodeRef::ValName(v) => v.name.span.clone(),
+        NodeRef::StructName(s) => s.name.span.clone(),
+        NodeRef::TypeAliasName(t) => t.name.span.clone(),
+        NodeRef::ParamName(p) => p.name.span.clone(),
+        NodeRef::UseName { name } => name.span.clone(),
+        _ => return None,
+    };
+    let _ = &target;
+    Some(PrepareRenameResponse::Range(
+        snap.index.range(snap.text, &span, snap.enc),
+    ))
+}
+
+pub fn handle_rename(state: &ServerState, params: &RenameParams) -> Option<WorkspaceEdit> {
+    let pos = &params.text_document_position;
+    let snap = snapshot_at(state, &pos.text_document.uri)?;
+    let target = resolve_target(&snap, pos)?;
+    let new_name = params.new_name.as_str();
+    if !is_valid_new_name(new_name) {
+        return None;
+    }
+    // clippy's mutable-key-type fires on Uri's interior cell; keys
+    // are never mutated after insertion.
+    #[allow(clippy::mutable_key_type)]
+    let mut changes: HashMap<Uri, Vec<TextEdit>> = HashMap::new();
+    for (uri, text, index, hits) in gather(state, &snap, &target) {
+        let edits: Vec<TextEdit> = hits
+            .iter()
+            .map(|hit| TextEdit {
+                range: index.range(&text, &hit.span, snap.enc),
+                new_text: match hit.kind {
+                    // `P { x }` → `P { x: new }`: the shorthand name
+                    // is both the field and the value; expanding keeps
+                    // the field spelling intact.
+                    HitKind::Shorthand => format!("{}: {new_name}", target.name),
+                    _ => new_name.to_string(),
+                },
+            })
+            .collect();
+        if !edits.is_empty() {
+            changes.entry(uri).or_default().extend(edits);
+        }
+    }
+    Some(WorkspaceEdit {
+        changes: Some(changes),
+        ..Default::default()
+    })
+}
+
+fn is_valid_new_name(name: &str) -> bool {
+    let mut chars = name.chars();
+    let starts_ok = chars.next().is_some_and(|c| c.is_alphabetic() || c == '_');
+    starts_ok
+        && name.chars().all(|c| c.is_alphanumeric() || c == '_')
+        && !RESERVED.contains(&name)
+        && !keron_modules::is_builtin_name(name)
+}
+
+/// Resolve the node under the cursor to its definition. `None` for
+/// non-renameable nodes: builtins, struct fields (a field rename
+/// can't find receivers whose type inference we don't do), use paths.
+fn resolve_target(snap: &Snapshot<'_>, pos: &TextDocumentPositionParams) -> Option<Target> {
+    let offset = snap.index.offset(snap.text, pos.position, snap.enc)?;
+    let (name, is_decl_site) = match node_at(snap.program, offset)? {
+        NodeRef::Callee(n) => (n.node.clone(), false),
+        NodeRef::Var { name, .. } | NodeRef::TypeName { name, .. } => (name.to_string(), false),
+        NodeRef::UseName { name } => (name.node.clone(), false),
+        NodeRef::FnName(f) => (f.name.node.clone(), true),
+        NodeRef::ValName(v) => (v.name.node.clone(), true),
+        NodeRef::StructName(s) => (s.name.node.clone(), true),
+        NodeRef::TypeAliasName(t) => (t.name.node.clone(), true),
+        NodeRef::ParamName(p) => (p.name.node.clone(), true),
+        NodeRef::StructFieldName(_) | NodeRef::FieldAccess { .. } | NodeRef::UsePath(_) => {
+            return None;
+        }
+    };
+    if keron_modules::is_builtin_name(&name) {
+        return None;
+    }
+    let _ = is_decl_site;
+    if let Some(def) = find_local_def(snap.program, &name, offset) {
+        let def_span = def.name_span();
+        let (local_only, param_of) = match &def {
+            LocalDef::Fn(_) | LocalDef::Struct(_) | LocalDef::TypeAlias(_) => (false, None),
+            LocalDef::Val(_) => (
+                top_level_decl_span(snap.program, &name) != Some(def_span.clone()),
+                None,
+            ),
+            LocalDef::Param(p) => (
+                true,
+                enclosing_fn_name(snap.program, &p.name.span).map(str::to_string),
+            ),
+            LocalDef::Binding { .. } => (true, None),
+        };
+        return Some(Target {
+            name,
+            home: snap.path.clone(),
+            def_span,
+            local_only,
+            param_of,
+        });
+    }
+    // Not local: follow this module's import to its origin.
+    let resolution = snap.resolution?;
+    let module = snap.module()?;
+    let (origin_id, original) = module.imports.get(&name)?;
+    let origin = resolution.graph.modules.get(origin_id)?;
+    let def_span = top_level_decl_span(&origin.program, original)?;
+    Some(Target {
+        name,
+        home: origin_id.0.clone(),
+        def_span,
+        local_only: false,
+        param_of: None,
+    })
+}
+
+fn enclosing_fn_name<'a>(program: &'a Program, param_span: &Span) -> Option<&'a str> {
+    program.items.iter().find_map(|item| match item {
+        Item::Fn(f) if f.span.start <= param_span.start && param_span.end <= f.span.end => {
+            Some(f.name.node.as_str())
+        }
+        _ => None,
+    })
+}
+
+/// Collect verified hits per module: the home module plus every
+/// module importing the name from it. Returns owned text because the
+/// snapshot's text and the graph modules' sources have different
+/// lifetimes.
+fn gather(
+    state: &ServerState,
+    snap: &Snapshot<'_>,
+    target: &Target,
+) -> Vec<(Uri, String, LineIndex, Vec<NameHit>)> {
+    let mut out = Vec::new();
+    let home_is_current = *snap.path == target.home;
+
+    // Home module: prefer the live snapshot when the definition lives
+    // in the current document.
+    if home_is_current {
+        out.extend(module_entry(
+            snap.doc.uri.clone(),
+            snap.program,
+            snap.text,
+            home_hits(snap.program, snap.text, target),
+        ));
+    } else if let Some(resolution) = state.resolution.as_ref()
+        && let Some(home) = resolution
+            .graph
+            .modules
+            .get(&keron_modules::ModuleId(target.home.clone()))
+        && let Some(uri) = path_to_uri(&target.home)
+    {
+        out.extend(module_entry(
+            uri,
+            &home.program,
+            &home.source,
+            home_hits(&home.program, &home.source, target),
+        ));
+    }
+
+    if target.local_only {
+        return out;
+    }
+
+    // Importing modules.
+    if let Some(resolution) = state.resolution.as_ref() {
+        for (id, module) in &resolution.graph.modules {
+            if id.0 == target.home {
+                continue;
+            }
+            // For a param rename, importers matter only via named
+            // args in calls to the *function*; otherwise the module
+            // must import the target name itself.
+            let import_key = target.param_of.as_deref().unwrap_or(&target.name);
+            let imports_it = module
+                .imports
+                .get(import_key)
+                .is_some_and(|(origin, orig)| {
+                    let from_home = origin.0 == target.home;
+                    from_home && orig == import_key
+                });
+            if !imports_it {
+                continue;
+            }
+            let (program, text): (&Program, &str) = if *snap.path == id.0 {
+                (snap.program, snap.text)
+            } else {
+                (&module.program, &module.source)
+            };
+            let hits = importer_hits(program, text, target);
+            if let Some(uri) = path_to_uri(&id.0) {
+                out.extend(module_entry(uri, program, text, hits));
+            }
+        }
+    }
+    out
+}
+
+fn module_entry(
+    uri: Uri,
+    _program: &Program,
+    text: &str,
+    hits: Vec<NameHit>,
+) -> Option<(Uri, String, LineIndex, Vec<NameHit>)> {
+    if hits.is_empty() {
+        return None;
+    }
+    Some((uri, text.to_string(), LineIndex::new(text), hits))
+}
+
+/// Hits in the module that holds the definition: the defining name
+/// itself, plus value refs verified against it (shadowed occurrences
+/// dropped) and callee/type refs (unshadowable namespaces).
+fn home_hits(program: &Program, text: &str, target: &Target) -> Vec<NameHit> {
+    let mut hits: Vec<NameHit> = collect_name_hits(program, text, &target.name)
+        .into_iter()
+        .filter(|hit| match hit.kind {
+            HitKind::Decl => hit.span == target.def_span,
+            HitKind::VarRef | HitKind::Shorthand => {
+                resolves_to(program, &target.name, hit.span.start, &target.def_span)
+            }
+            HitKind::CalleeRef | HitKind::TypeRef => true,
+            // A use-name for the same name inside the defining module
+            // would be an import collision the checker rejects.
+            HitKind::UseName => false,
+        })
+        .collect();
+    if let Some(fn_name) = &target.param_of {
+        hits.extend(
+            named_arg_spans(program, fn_name, &target.name)
+                .into_iter()
+                .map(|span| NameHit {
+                    span,
+                    kind: HitKind::VarRef,
+                }),
+        );
+        hits.sort_by_key(|h| h.span.start);
+    }
+    hits
+}
+
+/// Hits in a module that imports the name: everything that does NOT
+/// resolve to a local shadow (params/bindings may reuse the name).
+fn importer_hits(program: &Program, text: &str, target: &Target) -> Vec<NameHit> {
+    if let Some(fn_name) = &target.param_of {
+        return named_arg_spans(program, fn_name, &target.name)
+            .into_iter()
+            .map(|span| NameHit {
+                span,
+                kind: HitKind::VarRef,
+            })
+            .collect();
+    }
+    collect_name_hits(program, text, &target.name)
+        .into_iter()
+        .filter(|hit| match hit.kind {
+            // Local shadow declarations stay untouched.
+            HitKind::Decl => false,
+            HitKind::VarRef | HitKind::Shorthand => {
+                find_local_def(program, &target.name, hit.span.start).is_none()
+            }
+            HitKind::CalleeRef | HitKind::TypeRef | HitKind::UseName => true,
+        })
+        .collect()
+}

--- a/crates/keron-lsp/src/handlers/render.rs
+++ b/crates/keron-lsp/src/handlers/render.rs
@@ -51,6 +51,28 @@ pub fn param_label(p: &ParamSig) -> String {
     s
 }
 
+/// `name(p = $1, q = $2)$0` — a call snippet covering the required
+/// (non-defaulted) parameters; struct constructors use brace-literal
+/// shape instead.
+#[must_use]
+pub fn call_snippet(name: &str, sig: &FnSig) -> String {
+    let required: Vec<&ParamSig> = sig.params.iter().filter(|p| !p.has_default).collect();
+    if let Some(struct_name) = &sig.struct_name {
+        let fields: Vec<String> = required
+            .iter()
+            .enumerate()
+            .map(|(i, p)| format!("{}: ${{{}}}", p.name, i + 1))
+            .collect();
+        return format!("{struct_name} {{ {} }}$0", fields.join(", "));
+    }
+    let args: Vec<String> = required
+        .iter()
+        .enumerate()
+        .map(|(i, p)| format!("{} = ${{{}}}", p.name, i + 1))
+        .collect();
+    format!("{name}({})$0", args.join(", "))
+}
+
 /// `struct Name { field: T, … }` from a parsed declaration.
 #[must_use]
 pub fn struct_decl_signature(s: &StructDecl) -> String {

--- a/crates/keron-lsp/src/handlers/selection_range.rs
+++ b/crates/keron-lsp/src/handlers/selection_range.rs
@@ -1,0 +1,165 @@
+//! `textDocument/selectionRange` — the expand-selection chain: every
+//! enclosing expression/block/item span around the cursor, innermost
+//! first.
+
+use keron_lang::{Block, Expr, Span, Spanned, Stmt};
+use lsp_types::{SelectionRange, SelectionRangeParams};
+
+use crate::handlers::snapshot_at;
+use crate::state::ServerState;
+
+pub fn handle(state: &ServerState, params: &SelectionRangeParams) -> Option<Vec<SelectionRange>> {
+    let snap = snapshot_at(state, &params.text_document.uri)?;
+    let chains = params
+        .positions
+        .iter()
+        .map(|&position| {
+            let offset = snap
+                .index
+                .offset(snap.text, position, snap.enc)
+                .unwrap_or(0);
+            // Outermost → innermost enclosing spans at this offset.
+            let mut spans: Vec<Span> = Vec::new();
+            for item in &snap.program.items {
+                let span = item.span();
+                if span.start <= offset && offset < span.end {
+                    spans.push(span);
+                    item_spans(item, offset, &mut spans);
+                }
+            }
+            // Fold into a linked SelectionRange, outermost as the tail.
+            let mut chain: Option<SelectionRange> = None;
+            for span in spans {
+                chain = Some(SelectionRange {
+                    range: snap.index.range(snap.text, &span, snap.enc),
+                    parent: chain.map(Box::new),
+                });
+            }
+            chain.unwrap_or_else(|| SelectionRange {
+                range: lsp_types::Range::new(position, position),
+                parent: None,
+            })
+        })
+        .collect();
+    Some(chains)
+}
+
+fn item_spans(item: &keron_lang::Item, offset: usize, out: &mut Vec<Span>) {
+    use keron_lang::Item;
+    match item {
+        Item::Val(v) => expr_spans(&v.value, offset, out),
+        Item::Fn(f) => {
+            for p in &f.params {
+                if let Some(d) = &p.default {
+                    expr_spans(d, offset, out);
+                }
+            }
+            block_spans(&f.body, offset, out);
+        }
+        Item::Struct(s) => {
+            for f in &s.fields {
+                if let Some(d) = &f.default {
+                    expr_spans(d, offset, out);
+                }
+            }
+        }
+        Item::Reconcile(r) => {
+            for e in r.chains.iter().flatten() {
+                expr_spans(e, offset, out);
+            }
+        }
+        Item::ExprStmt(e) => expr_spans(e, offset, out),
+        Item::Use(_) | Item::TypeAlias(_) => {}
+    }
+}
+
+fn block_spans(b: &Block, offset: usize, out: &mut Vec<Span>) {
+    if !(b.span.start <= offset && offset < b.span.end) {
+        return;
+    }
+    out.push(b.span.clone());
+    for stmt in &b.stmts {
+        match stmt {
+            Stmt::Val(v) => expr_spans(&v.value, offset, out),
+            Stmt::Reconcile(r) => {
+                for e in r.chains.iter().flatten() {
+                    expr_spans(e, offset, out);
+                }
+            }
+            Stmt::Expr(e) => expr_spans(e, offset, out),
+        }
+    }
+    if let Some(t) = &b.trailing {
+        expr_spans(t, offset, out);
+    }
+}
+
+fn expr_spans(e: &Spanned<Expr>, offset: usize, out: &mut Vec<Span>) {
+    if !(e.span.start <= offset && offset < e.span.end) {
+        return;
+    }
+    out.push(e.span.clone());
+    match &e.node {
+        Expr::Unary { operand, .. } => expr_spans(operand, offset, out),
+        Expr::Binary { lhs, rhs, .. } => {
+            expr_spans(lhs, offset, out);
+            expr_spans(rhs, offset, out);
+        }
+        Expr::Interpolation(parts) => {
+            for p in parts {
+                if let keron_lang::StringPart::Expr { expr, .. } = p {
+                    expr_spans(expr, offset, out);
+                }
+            }
+        }
+        Expr::List(items) => {
+            for x in items {
+                expr_spans(x, offset, out);
+            }
+        }
+        Expr::Map(entries) => {
+            for en in entries {
+                expr_spans(&en.key, offset, out);
+                expr_spans(&en.value, offset, out);
+            }
+        }
+        Expr::Call { args, .. } => {
+            for a in args {
+                expr_spans(&a.value, offset, out);
+            }
+        }
+        Expr::StructLiteral { fields, .. } => {
+            for f in fields {
+                if let Some(v) = &f.value {
+                    expr_spans(v, offset, out);
+                }
+            }
+        }
+        Expr::If {
+            cond,
+            then_branch,
+            else_branch,
+        } => {
+            expr_spans(cond, offset, out);
+            block_spans(then_branch, offset, out);
+            block_spans(else_branch, offset, out);
+        }
+        Expr::For {
+            iter_expr, body, ..
+        } => {
+            expr_spans(iter_expr, offset, out);
+            block_spans(body, offset, out);
+        }
+        Expr::Field { receiver, .. } => expr_spans(receiver, offset, out),
+        Expr::Match { scrutinee, arms } => {
+            expr_spans(scrutinee, offset, out);
+            for arm in arms {
+                if let Some(g) = &arm.guard {
+                    expr_spans(g, offset, out);
+                }
+                expr_spans(&arm.body, offset, out);
+            }
+        }
+        Expr::Literal(_) | Expr::Var(_) => {}
+    }
+}

--- a/crates/keron-lsp/src/handlers/signature_help.rs
+++ b/crates/keron-lsp/src/handlers/signature_help.rs
@@ -26,6 +26,12 @@ pub fn handle(state: &ServerState, params: &SignatureHelpParams) -> Option<Signa
     )?;
 
     let label = render::fn_sig_signature(&ctx.callee.node, &sig);
+    let documentation = keron_modules::builtin_doc(&ctx.callee.node).map(|doc| {
+        Documentation::MarkupContent(lsp_types::MarkupContent {
+            kind: lsp_types::MarkupKind::Markdown,
+            value: doc.to_string(),
+        })
+    });
     let parameters: Vec<ParameterInformation> = sig
         .params
         .iter()
@@ -38,7 +44,7 @@ pub fn handle(state: &ServerState, params: &SignatureHelpParams) -> Option<Signa
     Some(SignatureHelp {
         signatures: vec![SignatureInformation {
             label,
-            documentation: None::<Documentation>,
+            documentation,
             parameters: Some(parameters),
             active_parameter,
         }],

--- a/crates/keron-lsp/src/handlers/workspace_symbol.rs
+++ b/crates/keron-lsp/src/handlers/workspace_symbol.rs
@@ -1,0 +1,53 @@
+//! `workspace/symbol` — top-level declarations across every module in
+//! the latest resolution, filtered by a case-insensitive substring
+//! query (the standard cheap fuzzy for small workspaces).
+
+use keron_lang::Item;
+use lsp_types::{Location, SymbolInformation, SymbolKind, WorkspaceSymbolParams};
+
+use crate::line_index::LineIndex;
+use crate::state::ServerState;
+use crate::uri::path_to_uri;
+
+pub fn handle(
+    state: &ServerState,
+    params: &WorkspaceSymbolParams,
+) -> Option<Vec<SymbolInformation>> {
+    let resolution = state.resolution.as_ref()?;
+    let query = params.query.to_lowercase();
+    let mut symbols = Vec::new();
+    for (id, module) in &resolution.graph.modules {
+        let Some(uri) = path_to_uri(&id.0) else {
+            continue;
+        };
+        let index = LineIndex::new(&module.source);
+        for item in &module.program.items {
+            let (name, kind, span) = match item {
+                Item::Fn(f) => (&f.name.node, SymbolKind::FUNCTION, &f.name.span),
+                Item::Val(v) => (&v.name.node, SymbolKind::CONSTANT, &v.name.span),
+                Item::Struct(s) => (&s.name.node, SymbolKind::STRUCT, &s.name.span),
+                Item::TypeAlias(t) => (&t.name.node, SymbolKind::ENUM, &t.name.span),
+                _ => continue,
+            };
+            if !query.is_empty() && !name.to_lowercase().contains(&query) {
+                continue;
+            }
+            // lsp-types keeps the deprecated `deprecated` field on
+            // SymbolInformation; construction still requires it.
+            #[allow(deprecated)]
+            symbols.push(SymbolInformation {
+                name: name.clone(),
+                kind,
+                tags: None,
+                deprecated: None,
+                location: Location {
+                    uri: uri.clone(),
+                    range: index.range(&module.source, span, state.encoding),
+                },
+                container_name: None,
+            });
+        }
+    }
+    symbols.sort_by(|a, b| a.name.cmp(&b.name));
+    Some(symbols)
+}

--- a/crates/keron-lsp/src/lib.rs
+++ b/crates/keron-lsp/src/lib.rs
@@ -57,14 +57,25 @@ pub fn run_stdio_server() -> Result<()> {
 /// Same contract as [`run_stdio_server`].
 pub fn run_with_connection(connection: &Connection) -> Result<()> {
     let (id, init_params) = connection.initialize_start()?;
-    let encoding = serde_json::from_value::<lsp_types::InitializeParams>(init_params)
-        .map_or(PositionEncoding::Utf16, |p| negotiate_encoding(&p));
+    let init = serde_json::from_value::<lsp_types::InitializeParams>(init_params).ok();
+    let encoding = init
+        .as_ref()
+        .map_or(PositionEncoding::Utf16, negotiate_encoding);
+    let snippet_support = init.as_ref().is_some_and(|p| {
+        p.capabilities
+            .text_document
+            .as_ref()
+            .and_then(|t| t.completion.as_ref())
+            .and_then(|c| c.completion_item.as_ref())
+            .and_then(|i| i.snippet_support)
+            .unwrap_or(false)
+    });
     let result = lsp_types::InitializeResult {
         capabilities: server_capabilities(encoding),
         server_info: None,
     };
     connection.initialize_finish(id, serde_json::to_value(result)?)?;
-    main_loop(connection, encoding)
+    main_loop(connection, encoding, snippet_support)
 }
 
 /// Prefer UTF-8 columns (byte offsets — free for us) when the client
@@ -103,6 +114,17 @@ fn server_capabilities(encoding: PositionEncoding) -> ServerCapabilities {
             retrigger_characters: None,
             work_done_progress_options: lsp_types::WorkDoneProgressOptions::default(),
         }),
+        references_provider: Some(OneOf::Left(true)),
+        rename_provider: Some(OneOf::Right(lsp_types::RenameOptions {
+            prepare_provider: Some(true),
+            work_done_progress_options: lsp_types::WorkDoneProgressOptions::default(),
+        })),
+        document_highlight_provider: Some(OneOf::Left(true)),
+        code_action_provider: Some(lsp_types::CodeActionProviderCapability::Simple(true)),
+        inlay_hint_provider: Some(OneOf::Left(true)),
+        workspace_symbol_provider: Some(OneOf::Left(true)),
+        folding_range_provider: Some(lsp_types::FoldingRangeProviderCapability::Simple(true)),
+        selection_range_provider: Some(lsp_types::SelectionRangeProviderCapability::Simple(true)),
         semantic_tokens_provider: Some(SemanticTokensServerCapabilities::SemanticTokensOptions(
             SemanticTokensOptions {
                 legend: SemanticTokensLegend {
@@ -118,9 +140,14 @@ fn server_capabilities(encoding: PositionEncoding) -> ServerCapabilities {
     }
 }
 
-fn main_loop(connection: &Connection, encoding: PositionEncoding) -> Result<()> {
+fn main_loop(
+    connection: &Connection,
+    encoding: PositionEncoding,
+    snippet_support: bool,
+) -> Result<()> {
     let mut state = ServerState {
         encoding,
+        snippet_support,
         ..Default::default()
     };
     for msg in &connection.receiver {

--- a/crates/keron-lsp/src/state.rs
+++ b/crates/keron-lsp/src/state.rs
@@ -40,6 +40,8 @@ pub struct Parsed {
 pub struct ServerState {
     /// Negotiated at initialize; every position on the wire uses it.
     pub encoding: PositionEncoding,
+    /// Whether the client renders `$1`-style snippet completions.
+    pub snippet_support: bool,
     pub docs: HashMap<PathBuf, Document>,
     /// Result of the most recent [`keron_modules::resolve_with_loader`]
     /// run over all open documents. Feature handlers read the graph;

--- a/crates/keron-lsp/tests/server.rs
+++ b/crates/keron-lsp/tests/server.rs
@@ -458,3 +458,213 @@ fn utf8_position_encoding_is_negotiated() {
     );
     client.shutdown();
 }
+
+#[test]
+fn rename_rewrites_definition_and_importers() {
+    let proj = TempProject::new("rename");
+    let lib = proj.write(
+        "lib.keron",
+        "fn greet(who: String): String { \"hi \" + who }\n",
+    );
+    let main = proj.write("main.keron", "");
+    let main_uri = file_uri(&main);
+    let lib_uri = file_uri(&fs::canonicalize(&lib).expect("lib exists"));
+    let src = "from \"./lib.keron\" use greet\nval g: String = greet(\"you\")\n";
+    let mut client = Client::start();
+    client.open(&main_uri, src);
+
+    let result = client.request(
+        "textDocument/rename",
+        serde_json::json!({
+            "textDocument": {"uri": main_uri.as_str()},
+            "position": pos_of(src, "greet(\"you\")", 2),
+            "newName": "welcome",
+        }),
+    );
+    let edit: lsp_types::WorkspaceEdit = serde_json::from_value(result).expect("workspace edit");
+    // Uri's interior cell trips clippy's mutable-key-type; the map is
+    // read-only here.
+    #[allow(clippy::mutable_key_type)]
+    let changes = edit.changes.expect("changes map");
+    let main_edits = changes.get(&main_uri).expect("edits in main");
+    // use-name + callee reference.
+    assert_eq!(main_edits.len(), 2, "main edits: {main_edits:?}");
+    assert!(main_edits.iter().all(|e| e.new_text == "welcome"));
+    let lib_edits = changes.get(&lib_uri).expect("edits in lib");
+    assert_eq!(lib_edits.len(), 1, "lib edits: {lib_edits:?}");
+    assert_eq!(lib_edits[0].range.start, Position::new(0, 3));
+    client.shutdown();
+}
+
+#[test]
+fn references_cross_module_and_respect_shadowing() {
+    let proj = TempProject::new("refs");
+    let path = proj.write("main.keron", "");
+    let uri = file_uri(&path);
+    let src = "val x: Int = 1\nfn f(x: Int): Int { x }\nval y: Int = x\n";
+    let mut client = Client::start();
+    client.open(&uri, src);
+
+    let result = client.request(
+        "textDocument/references",
+        serde_json::json!({
+            "textDocument": {"uri": uri.as_str()},
+            "position": pos_of(src, "x: Int = 1", 0),
+            "context": {"includeDeclaration": true},
+        }),
+    );
+    let locations: Vec<lsp_types::Location> = serde_json::from_value(result).expect("locations");
+    // The decl and the `val y` reference — NOT the param-shadowed
+    // body occurrence.
+    assert_eq!(locations.len(), 2, "got: {locations:?}");
+    assert!(locations.iter().all(|l| l.uri == uri));
+    client.shutdown();
+}
+
+#[test]
+fn inlay_hints_show_inferred_types_and_param_names() {
+    let proj = TempProject::new("hints");
+    let path = proj.write("main.keron", "");
+    let uri = file_uri(&path);
+    let src = "val greeting = \"hello\"\nval s: Symlink = symlink(\"a\", \"b\")\nreconcile s\n";
+    let mut client = Client::start();
+    client.open(&uri, src);
+
+    let result = client.request(
+        "textDocument/inlayHint",
+        serde_json::json!({
+            "textDocument": {"uri": uri.as_str()},
+            "range": {"start": {"line": 0, "character": 0}, "end": {"line": 3, "character": 0}},
+        }),
+    );
+    let hints: Vec<lsp_types::InlayHint> = serde_json::from_value(result).expect("hints");
+    let labels: Vec<String> = hints
+        .iter()
+        .map(|h| match &h.label {
+            lsp_types::InlayHintLabel::String(s) => s.clone(),
+            other @ lsp_types::InlayHintLabel::LabelParts(_) => {
+                panic!("unexpected label {other:?}")
+            }
+        })
+        .collect();
+    assert!(
+        labels.contains(&": String".to_string()),
+        "inferred val type hint missing: {labels:?}"
+    );
+    assert!(
+        labels.contains(&"source = ".to_string()) && labels.contains(&"target = ".to_string()),
+        "param name hints missing: {labels:?}"
+    );
+    client.shutdown();
+}
+
+#[test]
+fn code_action_offers_did_you_mean_quickfix() {
+    let proj = TempProject::new("quickfix");
+    let path = proj.write("main.keron", "");
+    let uri = file_uri(&path);
+    let src = "val name: String = \"x\"\nval a: String = nane\n";
+    let mut client = Client::start();
+    client.open(&uri, src);
+    let published = client.diagnostics();
+    let diag = published
+        .diagnostics
+        .iter()
+        .find(|d| d.message.contains("did you mean"))
+        .expect("suggestion diagnostic")
+        .clone();
+
+    let result = client.request(
+        "textDocument/codeAction",
+        serde_json::json!({
+            "textDocument": {"uri": uri.as_str()},
+            "range": diag.range,
+            "context": {"diagnostics": [diag]},
+        }),
+    );
+    let actions: Vec<lsp_types::CodeActionOrCommand> =
+        serde_json::from_value(result).expect("actions");
+    let lsp_types::CodeActionOrCommand::CodeAction(action) = &actions[0] else {
+        panic!("expected code action");
+    };
+    assert_eq!(action.title, "Replace with `name`");
+    #[allow(clippy::mutable_key_type)] // read-only Uri-keyed map
+    let edit = action
+        .edit
+        .as_ref()
+        .and_then(|e| e.changes.as_ref())
+        .expect("edit");
+    assert_eq!(edit[&uri][0].new_text, "name");
+    client.shutdown();
+}
+
+#[test]
+fn workspace_symbols_folding_and_selection_ranges_answer() {
+    let proj = TempProject::new("navigation");
+    let path = proj.write("main.keron", "");
+    let uri = file_uri(&path);
+    let src = "fn helper(a: Int): Int {\n  a + 1\n}\nval answer: Int = helper(41)\n";
+    let mut client = Client::start();
+    client.open(&uri, src);
+
+    let symbols: Vec<lsp_types::SymbolInformation> = serde_json::from_value(
+        client.request("workspace/symbol", serde_json::json!({"query": "help"})),
+    )
+    .expect("symbols");
+    assert_eq!(symbols.len(), 1);
+    assert_eq!(symbols[0].name, "helper");
+
+    let folds: Vec<lsp_types::FoldingRange> = serde_json::from_value(client.request(
+        "textDocument/foldingRange",
+        serde_json::json!({"textDocument": {"uri": uri.as_str()}}),
+    ))
+    .expect("folding ranges");
+    assert!(
+        folds.iter().any(|f| f.start_line == 0 && f.end_line == 2),
+        "fn body fold missing: {folds:?}"
+    );
+
+    let chains: Vec<lsp_types::SelectionRange> = serde_json::from_value(client.request(
+        "textDocument/selectionRange",
+        serde_json::json!({
+            "textDocument": {"uri": uri.as_str()},
+            "positions": [pos_of(src, "a + 1", 0)],
+        }),
+    ))
+    .expect("selection ranges");
+    // Innermost `a` → `a + 1` → block → fn item: at least 3 levels.
+    let mut depth = 0;
+    let mut cur = Some(&chains[0]);
+    while let Some(c) = cur {
+        depth += 1;
+        cur = c.parent.as_deref();
+    }
+    assert!(depth >= 3, "selection chain too shallow: {depth}");
+    client.shutdown();
+}
+
+#[test]
+fn document_highlight_marks_decl_and_reads() {
+    let proj = TempProject::new("highlight");
+    let path = proj.write("main.keron", "");
+    let uri = file_uri(&path);
+    let src = "val count: Int = 1\nval more: Int = count + count\n";
+    let mut client = Client::start();
+    client.open(&uri, src);
+
+    let highlights: Vec<lsp_types::DocumentHighlight> = serde_json::from_value(client.request(
+        "textDocument/documentHighlight",
+        serde_json::json!({
+            "textDocument": {"uri": uri.as_str()},
+            "position": pos_of(src, "count + count", 1),
+        }),
+    ))
+    .expect("highlights");
+    assert_eq!(highlights.len(), 3, "got: {highlights:?}");
+    let writes = highlights
+        .iter()
+        .filter(|h| h.kind == Some(lsp_types::DocumentHighlightKind::WRITE))
+        .count();
+    assert_eq!(writes, 1, "exactly the decl is a write");
+    client.shutdown();
+}

--- a/crates/keron-modules/src/lib.rs
+++ b/crates/keron-modules/src/lib.rs
@@ -74,6 +74,10 @@ pub struct CheckedModule {
     /// slot. The evaluator coerces the runtime value at these spans —
     /// see `CheckOutput::double_promotions`.
     pub double_promotions: HashSet<(usize, usize)>,
+    /// Inferred types of unannotated top-level `val`s, keyed by the
+    /// name's byte span — see `CheckOutput::val_types`. Editor
+    /// tooling reads this for inlay hints and hover.
+    pub val_types: HashMap<(usize, usize), Type>,
 }
 
 /// All modules reachable from the entry roots, indexed for evaluation.
@@ -229,6 +233,13 @@ pub fn imported_symbols(module: &CheckedModule, graph: &ModuleGraph) -> Imported
 #[must_use]
 pub fn stdlib_symbols() -> ImportedSymbols {
     build_imported_symbols(&HashMap::new(), &HashMap::new())
+}
+
+/// True when `name` is a stdlib builtin (fn or type) — unshadowable
+/// and therefore also un-renameable from user code.
+#[must_use]
+pub fn is_builtin_name(name: &str) -> bool {
+    stdlib_builtin_names().contains(name)
 }
 
 /// Prose documentation (markdown) for the builtin fn named `name`, or
@@ -399,9 +410,13 @@ impl<'a> ResolveState<'a> {
             // "expected `X`, found `X`" mismatches where one side is
             // the unresolved name and the other the canonical variant.
             let mut double_promotions = HashSet::new();
+            let mut val_types = HashMap::new();
             match resolve_type_names(&mut program, &imported) {
                 Ok(()) => match check_module_full(&program, &imported) {
-                    Ok(output) => double_promotions = output.double_promotions,
+                    Ok(output) => {
+                        double_promotions = output.double_promotions;
+                        val_types = output.val_types;
+                    }
                     Err(diags) => {
                         self.errors.push(ResolveError {
                             module: id.clone(),
@@ -428,6 +443,7 @@ impl<'a> ResolveState<'a> {
                     exported_vals,
                     exported_types,
                     double_promotions,
+                    val_types,
                 },
             );
         }
@@ -1062,6 +1078,7 @@ mod tests {
             exported_vals: vals,
             exported_types: HashMap::new(),
             double_promotions: HashSet::new(),
+            val_types: HashMap::new(),
         };
         assert_eq!(val_type_for(&module, "s"), Some(Type::String));
         assert_eq!(val_type_for(&module, "n"), Some(Type::Int));
@@ -1081,6 +1098,7 @@ mod tests {
             exported_vals: vals,
             exported_types: HashMap::new(),
             double_promotions: HashSet::new(),
+            val_types: HashMap::new(),
         };
         assert_eq!(val_type_for(&module, "v"), None);
     }
@@ -1137,6 +1155,7 @@ mod tests {
             exported_vals: vals,
             exported_types: types,
             double_promotions: HashSet::new(),
+            val_types: HashMap::new(),
         };
         let sig = sig_for(&module, "only").expect("`only` is exported");
         assert_eq!(sig.return_type, Type::String);


### PR DESCRIPTION
## What

The remaining LSP feature surface, completing the horizon left after #41. The server now advertises **15 providers**.

**Reference engine** (`analysis/refs.rs`): classifies every occurrence of a name — declaration, value ref, callee, type position (textually refined to the exact identifier inside annotations like `List<Point>`), `use` item, shorthand field. Value references are verified through scope resolution, so param/binding-shadowed occurrences never leak into results. Field-name positions are excluded by construction (separate namespace).

**On top of it:**
- `textDocument/references` — same-module + cross-module through the import graph.
- `textDocument/rename` (+ `prepareRename`) — WorkspaceEdit spanning the defining module and every importer. Shorthand fields (`P { x }`) expand to `x: newName` so the field spelling survives; param renames also rewrite named arguments at call sites (cross-file included); builtins, keywords, and struct fields are refused.
- `textDocument/documentHighlight` — decl as WRITE, references as READ.
- `textDocument/codeAction` — the checker's ``did you mean `X`?`` suggestions become one-click quickfixes, stateless (parsed from the diagnostics the client echoes back).
- `textDocument/inlayHint` — inferred types on unannotated vals (new `CheckOutput::val_types` byproduct from the checker) + parameter names on positional arguments. Hover on an unannotated val now shows its inferred type too.
- `workspace/symbol`, `textDocument/foldingRange` (items, expression blocks, multiline strings, comment runs), `textDocument/selectionRange` (expand-selection chains).
- Completion emits **snippet** insert text (`symlink(source = $1, target = $2)$0`) when the client supports snippets; signature help now carries builtin prose docs.

**Deliberately not implemented** (documented decisions, not omissions): incremental text sync and semantic-token deltas (pure perf with zero user-visible value at dotfile scale), and diagnostic severity tiers (the language currently produces no warnings — plumbing without a producer).

## Verification

- `just` green: **1741 tests** (+14 over main): refs-collector unit tests (scoping, word-boundary type refinement, shorthand flagging, field-position exclusion) and 6 new e2e scenarios (cross-file rename asserting exact edit sets, shadow-aware references, inlay hint labels, quickfix round-trip, workspace-symbol/folding/selection, document highlight).
- Real-binary stdio smoke: utf-8 negotiated, all 15 providers advertised, clean exit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)